### PR TITLE
Fix prefetched data loading

### DIFF
--- a/fortuna/data/loader.py
+++ b/fortuna/data/loader.py
@@ -809,7 +809,7 @@ class PrefetchedGenerator:
         self._ready = False
         return self._batch
 
-    def prefetch(self):
+    def _prefetch(self):
         if not self._ready:
             self._batch = self._generator.__next__()
             self._ready = True

--- a/tests/fortuna/test_data.py
+++ b/tests/fortuna/test_data.py
@@ -3,8 +3,7 @@ import unittest
 import numpy as np
 
 from fortuna.data.loader import DataLoader, InputsLoader, TargetsLoader
-from tests.make_data import (make_generator_fun_random_data,
-                             make_generator_random_data)
+from tests.make_data import make_array_random_data, make_generator_fun_random_data, make_generator_random_data
 
 
 class Test(unittest.TestCase):
@@ -35,6 +34,18 @@ class Test(unittest.TestCase):
         for a in inputs:
             assert type(a) == np.ndarray
             assert a.shape == (3, 5)
+
+    def test_array_data(self):
+        data_org = make_array_random_data(
+            n_data=10,
+            shape_inputs=(2,),
+            output_dim=1,
+            output_type="continuous",
+        )
+        for prefetch in [False, True]:
+            data_new = DataLoader.from_array_data(data_org, batch_size=2, prefetch=prefetch).to_array_data()
+            for original, new in zip(data_org, data_new):
+                assert (original == new).all()
 
 
 class TestGetTargets(unittest.TestCase):


### PR DESCRIPTION
Interesting library!

*Description of changes:*
I was checking out the examples, and found a small but easy to fix issue:

Loading data with prefetching resulted in a runtime error due to a typo inside `PrefetchedGenerator`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
