### PR TITLE
check if calibrator is none instead of calibrator manager

### DIFF
--- a/fortuna/prob_model/base.py
+++ b/fortuna/prob_model/base.py
@@ -107,7 +107,7 @@ class ProbModel(abc.ABC):
         check_data_loader_is_not_random(calib_data_loader)
         if val_data_loader is not None:
             check_data_loader_is_not_random(val_data_loader)
-        if self.output_calib_manager is None:
+        if self.output_calib_manager.output_calibrator is None:
             logging.warning(
                 """Nothing to calibrate. No calibrator was passed to the probabilistic model."""
             )

--- a/fortuna/prob_model/likelihood/base.py
+++ b/fortuna/prob_model/likelihood/base.py
@@ -386,7 +386,7 @@ class Likelihood(WithRNG):
         """
         outputs = self.get_outputs(params, inputs_loader, mutable, distribute, **kwargs)
 
-        if self.output_calib_manager is not None:
+        if self.output_calib_manager.output_calibrator is not None:
             outputs = self.output_calib_manager.apply(
                 params=calib_params["output_calibrator"]
                 if calib_params is not None
@@ -410,7 +410,7 @@ class Likelihood(WithRNG):
     ) -> jnp.ndarray:
         outputs = self.model_manager.apply(params, inputs, mutable, **kwargs)
 
-        if self.output_calib_manager is not None:
+        if self.output_calib_manager.output_calibrator is not None:
             outputs = self.output_calib_manager.apply(
                 params=calib_params["output_calibrator"]
                 if calib_params is not None


### PR DESCRIPTION
Check whether the `output_calibrator` is `None`, not the `output_calib_manager`.

## Pull request type

Please check the type of change your PR introduces:

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We erroneously check whether the `output_calib_manager` is `None`, but this is never the case.

## What is the new behavior?

Check whether `output_calibrator` is `None`.
