### PR TITLE
Fix random seeds

### DIFF
--- a/fortuna/data/loader.py
+++ b/fortuna/data/loader.py
@@ -50,6 +50,7 @@ class DataLoader:
         batch_size: Optional[int] = None,
         shuffle: bool = False,
         prefetch: bool = False,
+        seed: Optional[int] = 0,
     ) -> DataLoader:
         """
         Build a :class:`~fortuna.data.loader.DataLoader` object from a tuple of arrays of input and target variables,
@@ -73,7 +74,7 @@ class DataLoader:
         """
         return cls(
             data_loader=FromArrayDataToDataLoader(
-                data, batch_size=batch_size, shuffle=shuffle, prefetch=prefetch
+                data, batch_size=batch_size, shuffle=shuffle, prefetch=prefetch, seed=seed
             )
         )
 
@@ -449,6 +450,7 @@ class InputsLoader:
         batch_size: Optional[int] = None,
         shuffle: bool = False,
         prefetch: bool = False,
+        seed: Optional[int] = 0,
     ) -> InputsLoader:
         """
         Build a :class:`~fortuna.data.loader.InputsLoader` object from an array of input data.
@@ -726,6 +728,7 @@ class TargetsLoader:
         batch_size: Optional[int] = None,
         shuffle: bool = False,
         prefetch: bool = False,
+        seed: Optional[int] = 0,
     ) -> TargetsLoader:
         """
         Build a :class:`~fortuna.data.loader.TargetsLoader` object from an array of target data.
@@ -748,7 +751,7 @@ class TargetsLoader:
         """
         return cls(
             targets_loader=FromArrayTargetsToTargetsLoader(
-                targets, batch_size=batch_size, shuffle=shuffle, prefetch=prefetch
+                targets, batch_size=batch_size, shuffle=shuffle, prefetch=prefetch, seed=seed
             )
         )
 
@@ -980,15 +983,18 @@ class FromArrayDataToDataLoader:
         batch_size: Optional[int] = None,
         shuffle: bool = False,
         prefetch: bool = False,
+        seed: Optional[int] = 0,
     ):
         self._data = data
         self._batch_size = batch_size
         self._shuffle = shuffle
         self._prefetch = prefetch
+        self._seed = seed
 
     def __call__(self, *args, **kwargs):
         if self._shuffle:
-            perm = np.random.choice(
+            rng = np.random.default_rng(self._seed)
+            perm = rng.choice(
                 self._data[0].shape[0], self._data[0].shape[0], replace=False
             )
         if self._batch_size is None:
@@ -1139,15 +1145,18 @@ class FromArrayInputsToInputsLoader:
         batch_size: Optional[int] = None,
         shuffle: bool = False,
         prefetch: bool = False,
+        seed: Optional[int] = 0,
     ):
         self._inputs = inputs
         self._batch_size = batch_size
         self._shuffle = shuffle
         self._prefetch = prefetch
+        self._seed = seed
 
     def __call__(self, *args, **kwargs):
         if self._shuffle:
-            perm = np.random.choice(
+            rng = np.random.default_rng(self._seed)
+            perm = rng.choice(
                 self._inputs.shape[0], self._inputs.shape[0], replace=False
             )
         if self._batch_size is None:
@@ -1208,15 +1217,18 @@ class FromArrayTargetsToTargetsLoader:
         batch_size: Optional[int] = None,
         shuffle: bool = False,
         prefetch: bool = False,
+        seed: Optional[int] = 0,
     ):
         self._targets = targets
         self._batch_size = batch_size
         self._shuffle = shuffle
         self._prefetch = prefetch
+        self._seed = seed
 
     def __call__(self, *args, **kwargs):
         if self._shuffle:
-            perm = np.random.choice(
+            rng = np.random.default_rng(self._seed)
+            perm = rng.choice(
                 self._targets.shape[0], self._targets.shape[0], replace=False
             )
         if self._batch_size is None:

--- a/fortuna/prob_model/posterior/normalizing_flow/advi/advi_architecture.py
+++ b/fortuna/prob_model/posterior/normalizing_flow/advi/advi_architecture.py
@@ -25,7 +25,7 @@ class ADVIArchitecture(HashableMixin):
         self.dim = dim
         self.std_init_params = std_init_params
 
-    def forward(self, params: any, u: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    def forward(self, params: Any, u: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """
         Component-wise forward linear transformation.
 

--- a/tests/fortuna/test_conformal_methods.py
+++ b/tests/fortuna/test_conformal_methods.py
@@ -16,12 +16,10 @@ from fortuna.calibration import (
 from fortuna.data.loader import DataLoader, InputsLoader
 
 
-np.random.rand(42)
-
-
 class TestConformalMethods(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._rng = np.random.default_rng(0)
 
     def test_prediction_conformal_classifier(self):
         val_probs = np.array([[0.1, 0.9], [0.8, 0.2], [0.3, 0.7]])
@@ -63,11 +61,11 @@ class TestConformalMethods(unittest.TestCase):
     def test_quantile_conformal_regressor(self):
         n_val_inputs = 100
         n_test_inputs = 100
-        val_lower_quantiles = np.random.normal(size=n_val_inputs)
-        val_upper_quantiles = np.random.normal(size=n_val_inputs)
-        test_lower_quantiles = np.random.normal(size=n_test_inputs)
-        test_upper_quantiles = np.random.normal(size=n_test_inputs)
-        val_targets = np.random.normal(size=(n_val_inputs, 1))
+        val_lower_quantiles = self._rng.normal(size=n_val_inputs)
+        val_upper_quantiles = self._rng.normal(size=n_val_inputs)
+        test_lower_quantiles = self._rng.normal(size=n_test_inputs)
+        test_upper_quantiles = self._rng.normal(size=n_test_inputs)
+        val_targets = self._rng.normal(size=(n_val_inputs, 1))
 
         conformal = QuantileConformalRegressor()
         scores = conformal.score(val_lower_quantiles, val_upper_quantiles, val_targets)
@@ -94,11 +92,11 @@ class TestConformalMethods(unittest.TestCase):
     def test_one_dimensional_uncertainty_conformal_regressor(self):
         n_val_inputs = 100
         n_test_inputs = 10
-        val_preds = np.random.normal(size=n_val_inputs)[:, None]
-        val_uncertainties = np.exp(np.random.normal(size=n_val_inputs))[:, None]
-        test_preds = np.random.normal(size=n_test_inputs)[:, None]
-        test_uncertainties = np.exp(np.random.normal(size=n_test_inputs))[:, None]
-        val_targets = np.random.normal(size=(n_val_inputs, 1))
+        val_preds = self._rng.normal(size=n_val_inputs)[:, None]
+        val_uncertainties = np.exp(self._rng.normal(size=n_val_inputs))[:, None]
+        test_preds = self._rng.normal(size=n_test_inputs)[:, None]
+        test_uncertainties = np.exp(self._rng.normal(size=n_test_inputs))[:, None]
+        val_targets = self._rng.normal(size=(n_val_inputs, 1))
 
         conformal = OneDimensionalUncertaintyConformalRegressor()
         scores = conformal.score(val_preds, val_uncertainties, val_targets)
@@ -131,19 +129,19 @@ class TestConformalMethods(unittest.TestCase):
         k1, k2, k3 = 100, 101, 102
         m = 99
         cross_val_outputs = [
-            np.random.normal(size=(k1, 1)),
-            np.random.normal(size=(k2, 1)),
-            np.random.normal(size=(k3, 1)),
+            self._rng.normal(size=(k1, 1)),
+            self._rng.normal(size=(k2, 1)),
+            self._rng.normal(size=(k3, 1)),
         ]
         cross_val_targets = [
-            np.random.normal(size=(k1, 1)),
-            np.random.normal(size=(k2, 1)),
-            np.random.normal(size=(k3, 1)),
+            self._rng.normal(size=(k1, 1)),
+            self._rng.normal(size=(k2, 1)),
+            self._rng.normal(size=(k3, 1)),
         ]
         cross_test_outputs = [
-            np.random.normal(size=(m, 1)),
-            np.random.normal(size=(m, 1)),
-            np.random.normal(size=(m, 1)),
+            self._rng.normal(size=(m, 1)),
+            self._rng.normal(size=(m, 1)),
+            self._rng.normal(size=(m, 1)),
         ]
 
         intervals = CVPlusConformalRegressor().conformal_interval(
@@ -159,9 +157,9 @@ class TestConformalMethods(unittest.TestCase):
     def test_jackknifeplus_conformal_regressor(self):
         n = 100
         m = 99
-        loo_val_outputs = np.random.normal(size=(n, 1))
-        loo_val_targets = np.random.normal(size=(n, 1))
-        loo_test_outputs = np.random.normal(size=(n, m, 1))
+        loo_val_outputs = self._rng.normal(size=(n, 1))
+        loo_val_targets = self._rng.normal(size=(n, 1))
+        loo_test_outputs = self._rng.normal(size=(n, m, 1))
 
         intervals = JackknifePlusConformalRegressor().conformal_interval(
             loo_val_outputs, loo_val_targets, loo_test_outputs, 0.05
@@ -176,9 +174,9 @@ class TestConformalMethods(unittest.TestCase):
     def test_jackknife_minmax_conformal_regressor(self):
         n = 100
         m = 99
-        loo_val_outputs = np.random.normal(size=(n, 1))
-        loo_val_targets = np.random.normal(size=(n, 1))
-        loo_test_outputs = np.random.normal(size=(n, m, 1))
+        loo_val_outputs = self._rng.normal(size=(n, 1))
+        loo_val_targets = self._rng.normal(size=(n, 1))
+        loo_test_outputs = self._rng.normal(size=(n, m, 1))
 
         intervals = JackknifeMinmaxConformalRegressor().conformal_interval(
             loo_val_outputs, loo_val_targets, loo_test_outputs, 0.05
@@ -198,10 +196,10 @@ class TestConformalMethods(unittest.TestCase):
 
         for b in bs:
             # all without extra scalar dimension
-            bootstrap_indices = np.random.choice(t, size=(b, t))
-            bootstrap_train_preds = np.random.normal(size=(b, t))
-            bootstrap_test_preds = np.random.normal(size=(b, t1))
-            train_targets = np.random.normal(size=t)
+            bootstrap_indices = self._rng.choice(t, size=(b, t))
+            bootstrap_train_preds = self._rng.normal(size=(b, t))
+            bootstrap_test_preds = self._rng.normal(size=(b, t1))
+            train_targets = self._rng.normal(size=t)
 
             intervals = EnbPI().conformal_interval(
                 bootstrap_indices=bootstrap_indices,
@@ -218,9 +216,9 @@ class TestConformalMethods(unittest.TestCase):
             assert len(np.unique(intervals[:, 1])) > 1
 
             # all with extra scalar dimension
-            bootstrap_train_preds = np.random.normal(size=(b, t, 1))
-            bootstrap_test_preds = np.random.normal(size=(b, t1, 1))
-            train_targets = np.random.normal(size=(t, 1))
+            bootstrap_train_preds = self._rng.normal(size=(b, t, 1))
+            bootstrap_test_preds = self._rng.normal(size=(b, t1, 1))
+            train_targets = self._rng.normal(size=(t, 1))
 
             intervals = EnbPI().conformal_interval(
                 bootstrap_indices=bootstrap_indices,
@@ -237,7 +235,7 @@ class TestConformalMethods(unittest.TestCase):
             assert len(np.unique(intervals[:, 1])) > 1
 
             # predictions with and targets without extra scalar dimension
-            train_targets = np.random.normal(size=t)
+            train_targets = self._rng.normal(size=t)
 
             intervals = EnbPI().conformal_interval(
                 bootstrap_indices=bootstrap_indices,
@@ -254,7 +252,7 @@ class TestConformalMethods(unittest.TestCase):
             assert len(np.unique(intervals[:, 1])) > 1
 
             # return also residuals
-            train_targets = np.random.normal(size=t)
+            train_targets = self._rng.normal(size=t)
 
             intervals, residuals = EnbPI().conformal_interval(
                 bootstrap_indices=bootstrap_indices,
@@ -277,14 +275,14 @@ class TestConformalMethods(unittest.TestCase):
     def test_adaptive_conformal_regressor(self):
         acr = AdaptiveConformalRegressor(conformal_regressor=QuantileConformalRegressor())
         error = acr.update_error(
-            conformal_interval=np.random.normal(size=2),
+            conformal_interval=self._rng.normal(size=2),
             error=0.01,
             target=np.array([1.2]),
             target_error=0.05
         )
 
         error = acr.update_error(
-            conformal_interval=np.random.normal(size=2),
+            conformal_interval=self._rng.normal(size=2),
             error=0.01,
             target=np.array([1.2]),
             target_error=0.05,
@@ -317,11 +315,11 @@ class TestConformalMethods(unittest.TestCase):
             bounds_fn=lambda x, t: (x - t, x + t)
         )
         val_data_loader = DataLoader.from_array_data(
-            (np.random.normal(size=(50,)), np.random.normal(size=(50,))),
+            (self._rng.normal(size=(50,)), self._rng.normal(size=(50,))),
             batch_size=32,
         )
         test_inputs_loader = InputsLoader.from_array_inputs(
-            np.random.normal(size=(150,)),
+            self._rng.normal(size=(150,)),
             batch_size=32,
         )
 
@@ -335,11 +333,11 @@ class TestConformalMethods(unittest.TestCase):
             n_classes=2
         )
         val_data_loader = DataLoader.from_array_data(
-            (np.random.normal(size=(50, 1)), np.random.choice(2, 50)),
+            (self._rng.normal(size=(50, 1)), self._rng.choice(2, 50)),
             batch_size=32,
         )
         test_inputs_loader = InputsLoader.from_array_inputs(
-            np.random.normal(size=(150, 1)),
+            self._rng.normal(size=(150, 1)),
             batch_size=32,
         )
 

--- a/tests/make_data.py
+++ b/tests/make_data.py
@@ -1,42 +1,61 @@
-from typing import Callable, Generator, Tuple
+from typing import Callable, Generator, Tuple, Optional
 
 import numpy as np
 
 
+def _check_output_type(output_type):
+    if output_type not in ["discrete", "continuous"]:
+        raise Exception(
+            f"`output_type={output_type}` not recognized. " \
+            "Please choose among the following list: ['discrete', 'continuous']"
+        )
+
+
 def make_array_random_inputs(
-    n_inputs: int, shape_inputs: Tuple[int, ...]
+    n_inputs: int,
+    shape_inputs: Tuple[int, ...],
+    seed: Optional[int] = 0
 ) -> np.ndarray:
-    return np.random.normal(size=(n_inputs,) + shape_inputs)
+    rng = np.random.default_rng(seed)
+    return rng.normal(size=(n_inputs,) + shape_inputs)
 
 
 def make_generator_fun_random_inputs(
-    batch_size: int, n_batches: int, shape_inputs: Tuple[int, ...]
+    batch_size: int,
+    n_batches: int,
+    shape_inputs: Tuple[int, ...],
+    seed: Optional[int] = 0
 ) -> Callable[[], Generator[np.ndarray, None, None]]:
+    rng = np.random.default_rng(seed)
     def inner():
         for i in range(n_batches):
-            yield np.random.normal(size=(batch_size,) + shape_inputs)
-
+            yield rng.normal(size=(batch_size,) + shape_inputs)
     return inner
 
 
 def make_generator_random_inputs(
-    batch_size: int, n_batches: int, shape_inputs: Tuple[int, ...]
+    batch_size: int,
+    n_batches: int,
+    shape_inputs: Tuple[int, ...],
+    seed: Optional[int] = 0
 ) -> Generator[np.ndarray, None, None]:
+    rng = np.random.default_rng(seed)
     for i in range(n_batches):
-        yield np.random.normal(size=(batch_size,) + shape_inputs)
+        yield rng.normal(size=(batch_size,) + shape_inputs)
 
 
-def make_array_random_targets(n_inputs: int, output_dim: int, output_type: str):
-    if output_type not in ["discrete", "continuous"]:
-        raise Exception(
-            "`output_type={}` not recognized. Please choose among the following list: {}.".format(
-                "discrete", "continuous"
-            )
-        )
+def make_array_random_targets(
+    n_inputs: int,
+    output_dim: int,
+    output_type: str,
+    seed: Optional[int] = 0
+) -> np.ndarray:
+    _check_output_type(output_type)
+    rng = np.random.default_rng(seed)
     return (
-        np.random.normal(size=(n_inputs, output_dim))
+        rng.normal(size=(n_inputs, output_dim))
         if output_type == "continuous"
-        else np.random.choice(output_dim, size=n_inputs)
+        else rng.choice(output_dim, size=n_inputs)
     )
 
 
@@ -45,22 +64,17 @@ def make_generator_fun_random_targets(
     n_batches: int,
     output_dim: int,
     output_type: str,
+    seed: Optional[int] = 0,
 ) -> Callable[[], Generator[Tuple[np.ndarray, np.ndarray], None, None]]:
-    if output_type not in ["discrete", "continuous"]:
-        raise Exception(
-            "`output_type={}` not recognized. Please choose among the following list: {}.".format(
-                "discrete", "continuous"
-            )
-        )
-
+    _check_output_type(output_type)
+    rng = np.random.default_rng(seed)
     def inner():
         for i in range(n_batches):
-            yield np.random.normal(
+            yield rng.normal(
                 size=(batch_size, output_dim)
-            ) if output_type == "continuous" else np.random.choice(
+            ) if output_type == "continuous" else rng.choice(
                 output_dim, size=batch_size
             )
-
     return inner
 
 
@@ -69,35 +83,32 @@ def make_generator_random_targets(
     n_batches: int,
     output_dim: int,
     output_type: str,
+    seed: Optional[int] = 0,
 ) -> Generator[Tuple[np.ndarray, np.ndarray], None, None]:
-    if output_type not in ["discrete", "continuous"]:
-        raise Exception(
-            "`output_type={}` not recognized. Please choose among the following list: {}.".format(
-                "discrete", "continuous"
-            )
-        )
+    _check_output_type(output_type)
+    rng = np.random.default_rng(seed)
     for i in range(n_batches):
-        yield np.random.normal(
+        yield rng.normal(
             size=(batch_size, output_dim)
-        ) if output_type == "continuous" else np.random.choice(
+        ) if output_type == "continuous" else rng.choice(
             output_dim, size=batch_size
         )
 
 
 def make_array_random_data(
-    n_data: int, shape_inputs: Tuple[int, ...], output_dim: int, output_type: str
+    n_data: int,
+    shape_inputs: Tuple[int, ...],
+    output_dim: int,
+    output_type: str,
+    seed: Optional[int] = 0,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    if output_type not in ["discrete", "continuous"]:
-        raise Exception(
-            "`output_type={}` not recognized. Please choose among the following list: {}.".format(
-                "discrete", "continuous"
-            )
-        )
+    _check_output_type(output_type)
+    rng = np.random.default_rng(seed)
     return (
-        np.random.normal(size=(n_data,) + shape_inputs),
-        np.random.normal(size=(n_data, output_dim))
+        rng.normal(size=(n_data,) + shape_inputs),
+        rng.normal(size=(n_data, output_dim))
         if output_type == "continuous"
-        else np.random.choice(output_dim, size=n_data),
+        else rng.choice(output_dim, size=n_data),
     )
 
 
@@ -107,19 +118,15 @@ def make_generator_fun_random_data(
     shape_inputs: Tuple[int],
     output_dim: int,
     output_type: str,
+    seed: Optional[int] = 0,
 ) -> Callable[[], Generator[Tuple[np.ndarray, np.ndarray], None, None]]:
-    if output_type not in ["discrete", "continuous"]:
-        raise Exception(
-            "`output_type={}` not recognized. Please choose among the following list: {}.".format(
-                "discrete", "continuous"
-            )
-        )
-
+    _check_output_type(output_type)
+    rng = np.random.default_rng(seed)
     def inner():
         for i in range(n_batches):
-            yield np.random.normal(size=(batch_size,) + shape_inputs), np.random.normal(
+            yield rng.normal(size=(batch_size,) + shape_inputs), rng.normal(
                 size=(batch_size, output_dim)
-            ) if output_type == "continuous" else np.random.choice(
+            ) if output_type == "continuous" else rng.choice(
                 output_dim, size=batch_size
             )
 
@@ -132,16 +139,13 @@ def make_generator_random_data(
     shape_inputs: Tuple[int],
     output_dim: int,
     output_type: str,
+    seed: Optional[int] = 0,
 ) -> Generator[Tuple[np.ndarray, np.ndarray], None, None]:
-    if output_type not in ["discrete", "continuous"]:
-        raise Exception(
-            "`output_type={}` not recognized. Please choose among the following list: {}.".format(
-                "discrete", "continuous"
-            )
-        )
+    _check_output_type(output_type)
+    rng = np.random.default_rng(seed)
     for i in range(n_batches):
-        yield np.random.normal(size=(batch_size,) + shape_inputs), np.random.normal(
+        yield rng.normal(size=(batch_size,) + shape_inputs), rng.normal(
             size=(batch_size, output_dim)
-        ) if output_type == "continuous" else np.random.choice(
+        ) if output_type == "continuous" else rng.choice(
             output_dim, size=batch_size
         )


### PR DESCRIPTION
Fix random seeds in data loaders and tests to ensure reproducibility.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- `data.DataLoader` produces nondeterministic batch ordering when `shuffle=True`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `data.DataLoader` shuffles the data in a deterministic way. Setting `seed=None` reverts to the previous behavior
- additionally, unit tests now use random data with a fixed seed.