### PR TITLE
allow advi on custom subnetworks

### DIFF
--- a/fortuna/prob_model/base.py
+++ b/fortuna/prob_model/base.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, Optional
 
 import jax
 import jax.numpy as jnp
+from jax.tree_util import tree_map
 
 from fortuna.output_calib_model.state import OutputCalibState
 from fortuna.data.loader import DataLoader

--- a/fortuna/prob_model/base.py
+++ b/fortuna/prob_model/base.py
@@ -4,7 +4,6 @@ from typing import Callable, Dict, Optional
 
 import jax
 import jax.numpy as jnp
-from jax.tree_util import tree_map
 
 from fortuna.output_calib_model.state import OutputCalibState
 from fortuna.data.loader import DataLoader

--- a/fortuna/prob_model/posterior/base.py
+++ b/fortuna/prob_model/posterior/base.py
@@ -1,18 +1,23 @@
 import abc
 from typing import Optional, Tuple, Union
 
-from jax._src.prng import PRNGKeyArray
+from jax.tree_util import tree_map
 
 from fortuna.data.loader import DataLoader
 from fortuna.prob_model.fit_config.base import FitConfig
 from fortuna.prob_model.joint.base import Joint
-from fortuna.prob_model.joint.state import JointState
 from fortuna.prob_model.posterior.posterior_mixin import \
     WithPosteriorCheckpointingMixin
 from fortuna.prob_model.posterior.posterior_state_repository import \
     PosteriorStateRepository
 from fortuna.typing import Path, Status
 from fortuna.utils.random import WithRNG
+from fortuna.training.train_state import TrainState
+from fortuna.utils.nested_dicts import nested_get, nested_set, nested_unpair
+from flax.core import FrozenDict
+from jax._src.prng import PRNGKeyArray
+from fortuna.utils.random import generate_random_normal_like_tree
+from fortuna.prob_model.joint.state import JointState
 
 
 class PosteriorApproximator(abc.ABC):
@@ -48,6 +53,7 @@ class Posterior(WithRNG, WithPosteriorCheckpointingMixin):
         self,
         train_data_loader: DataLoader,
         val_data_loader: Optional[DataLoader] = None,
+        state: Optional[TrainState] = None,
     ) -> Tuple[JointState, int, Union[int, None]]:
         for i, (batch_inputs, batch_targets) in enumerate(train_data_loader):
             if i == 0:
@@ -58,7 +64,9 @@ class Posterior(WithRNG, WithPosteriorCheckpointingMixin):
         if val_data_loader is not None:
             n_val_data = val_data_loader.size
 
-        return self.joint.init(input_shape), n_train_data, n_val_data
+        if state is None:
+            state = self.joint.init(input_shape)
+        return state, n_train_data, n_val_data
 
     @abc.abstractmethod
     def fit(
@@ -144,4 +152,59 @@ class Posterior(WithRNG, WithPosteriorCheckpointingMixin):
             self.state.get(),
             checkpoint_path=checkpoint_path,
             keep=keep_top_n_checkpoints,
+        )
+
+    def _sample_diag_gaussian(self, rng: Optional[PRNGKeyArray] = None, **kwargs) -> JointState:
+        if rng is None:
+            rng = self.rng.get()
+        state = self.state.get()
+
+        if self.posterior_approximator.which_params is not None:
+            mean, std = nested_unpair(
+                state.params.unfreeze(),
+                self.posterior_approximator.which_params,
+                ("mean", "std"),
+            )
+
+            noise = generate_random_normal_like_tree(rng, std)
+            params = nested_set(
+                mean,
+                self.posterior_approximator.which_params,
+                tuple(
+                    [
+                        tree_map(
+                            lambda m, s, e: m + s * e,
+                            nested_get(mean, keys),
+                            nested_get(std, keys),
+                            nested_get(noise, keys),
+                        )
+                        for keys in self.posterior_approximator.which_params
+                    ]
+                ),
+            )
+            for k, v in params.items():
+                params[k] = FrozenDict(v)
+            state = state.replace(params=FrozenDict(params))
+        else:
+            mean, std = dict(), dict()
+            for k, v in state.params.items():
+                mean[k] = FrozenDict({"params": v["params"]["mean"]})
+                std[k] = FrozenDict({"params": v["params"]["std"]})
+
+            state = state.replace(
+                params=FrozenDict(
+                    tree_map(
+                        lambda m, s, e: m + s * e,
+                        mean,
+                        std,
+                        generate_random_normal_like_tree(rng, std),
+                    )
+                )
+            )
+
+        return JointState(
+            params=state.params,
+            mutable=state.mutable,
+            calib_params=state.calib_params,
+            calib_mutable=state.calib_mutable,
         )

--- a/fortuna/prob_model/posterior/gaussian_posterior.py
+++ b/fortuna/prob_model/posterior/gaussian_posterior.py
@@ -1,0 +1,67 @@
+import abc
+
+from fortuna.prob_model.posterior.base import Posterior
+from typing import Optional
+from flax.core import FrozenDict
+from jax._src.prng import PRNGKeyArray
+from fortuna.prob_model.joint.state import JointState
+from fortuna.utils.nested_dicts import nested_set, nested_unpair, nested_get
+from jax.tree_util import tree_map
+from fortuna.utils.random import generate_random_normal_like_tree
+
+
+class GaussianPosterior(Posterior, abc.ABC):
+    def _sample_diag_gaussian(self, rng: Optional[PRNGKeyArray] = None, **kwargs) -> JointState:
+        if rng is None:
+            rng = self.rng.get()
+        state = self.state.get()
+
+        if hasattr(self.posterior_approximator, "which_params") and self.posterior_approximator.which_params is not None:
+            mean, std = nested_unpair(
+                state.params.unfreeze(),
+                self.posterior_approximator.which_params,
+                ("mean", "std"),
+            )
+
+            noise = generate_random_normal_like_tree(rng, std)
+            params = nested_set(
+                d=mean,
+                key_paths=self.posterior_approximator.which_params,
+                objs=tuple(
+                    [
+                        tree_map(
+                            lambda m, s, e: m + s * e,
+                            nested_get(mean, keys),
+                            nested_get(std, keys),
+                            nested_get(noise, keys),
+                        )
+                        for keys in self.posterior_approximator.which_params
+                    ]
+                ),
+            )
+            for k, v in params.items():
+                params[k] = FrozenDict(v)
+            state = state.replace(params=FrozenDict(params))
+        else:
+            mean, std = dict(), dict()
+            for k, v in state.params.items():
+                mean[k] = FrozenDict({"params": v["params"]["mean"]})
+                std[k] = FrozenDict({"params": v["params"]["std"]})
+
+            state = state.replace(
+                params=FrozenDict(
+                    tree_map(
+                        lambda m, s, e: m + s * e,
+                        mean,
+                        std,
+                        generate_random_normal_like_tree(rng, std),
+                    )
+                )
+            )
+
+        return JointState(
+            params=state.params,
+            mutable=state.mutable,
+            calib_params=state.calib_params,
+            calib_mutable=state.calib_mutable,
+        )

--- a/fortuna/prob_model/posterior/laplace/laplace_approximator.py
+++ b/fortuna/prob_model/posterior/laplace/laplace_approximator.py
@@ -16,10 +16,10 @@ class LaplacePosteriorApproximator(PosteriorApproximator):
             approximation. If `which_params` is not available, the Laplace approximation will be over all parameters.
         """
         if which_params:
-            if type(which_params) != tuple:
+            if not isinstance(which_params, tuple):
                 raise ValueError("`which_params` must be a tuple of lists.")
             for list_keys in which_params:
-                if type(list_keys) != list:
+                if not isinstance(list_keys, list):
                     raise ValueError("Each element in `which_params` must be a list.")
         self.which_params = which_params
 

--- a/fortuna/prob_model/posterior/laplace/laplace_posterior.py
+++ b/fortuna/prob_model/posterior/laplace/laplace_posterior.py
@@ -256,57 +256,9 @@ class LaplacePosterior(Posterior):
         logging.info("Fit completed.")
         return status
 
-    def sample(self, rng: Optional[PRNGKeyArray] = None, **kwargs) -> JointState:
-        if rng is None:
-            rng = self.rng.get()
-        state = self.state.get()
-
-        if self.posterior_approximator.which_params:
-            mean, std = nested_unpair(
-                state.params.unfreeze(),
-                self.posterior_approximator.which_params,
-                ("mean", "std"),
-            )
-
-            noise = generate_random_normal_like_tree(rng, std)
-            params = nested_set(
-                mean,
-                self.posterior_approximator.which_params,
-                tuple(
-                    [
-                        tree_map(
-                            lambda m, s, e: m + s * e,
-                            nested_get(mean, keys),
-                            nested_get(std, keys),
-                            nested_get(noise, keys),
-                        )
-                        for keys in self.posterior_approximator.which_params
-                    ]
-                ),
-            )
-            for k, v in params.items():
-                params[k] = FrozenDict(v)
-            state = state.replace(params=FrozenDict(params))
-        else:
-            mean, std = dict(), dict()
-            for k, v in state.params.items():
-                mean[k] = FrozenDict({"params": v["params"]["mean"]})
-                std[k] = FrozenDict({"params": v["params"]["std"]})
-
-            state = state.replace(
-                params=FrozenDict(
-                    tree_map(
-                        lambda m, s, e: m + s * e,
-                        mean,
-                        std,
-                        generate_random_normal_like_tree(rng, std),
-                    )
-                )
-            )
-
-        return JointState(
-            params=state.params,
-            mutable=state.mutable,
-            calib_params=state.calib_params,
-            calib_mutable=state.calib_mutable,
-        )
+    def sample(
+        self,
+        rng: Optional[PRNGKeyArray] = None,
+        **kwargs,
+    ) -> JointState:
+        return self._sample_diag_gaussian(rng=rng, **kwargs)

--- a/fortuna/prob_model/posterior/laplace/laplace_posterior.py
+++ b/fortuna/prob_model/posterior/laplace/laplace_posterior.py
@@ -6,16 +6,14 @@ from typing import Dict, Optional
 import jax.numpy as jnp
 from flax.core import FrozenDict
 from jax import hessian, lax, vjp, devices, jit, pmap
-from jax.lax import psum
 from jax._src.prng import PRNGKeyArray
 from jax.flatten_util import ravel_pytree
-from jax.tree_util import tree_map
 
 from fortuna.data.loader import DataLoader, DeviceDimensionAugmentedDataLoader
 from fortuna.prob_model.fit_config.base import FitConfig
 from fortuna.prob_model.joint.base import Joint
 from fortuna.prob_model.joint.state import JointState
-from fortuna.prob_model.posterior.base import Posterior
+from fortuna.prob_model.posterior.gaussian_posterior import GaussianPosterior
 from fortuna.prob_model.posterior.laplace import LAPLACE_NAME
 from fortuna.prob_model.posterior.laplace.laplace_approximator import \
     LaplacePosteriorApproximator
@@ -29,11 +27,10 @@ from fortuna.prob_model.posterior.posterior_state_repository import \
 from fortuna.prob_model.prior.gaussian import (DiagonalGaussianPrior,
                                                IsotropicGaussianPrior)
 from fortuna.typing import CalibMutable, CalibParams, Mutable, Params, Status
-from fortuna.utils.nested_dicts import nested_get, nested_set, nested_unpair
-from fortuna.utils.random import generate_random_normal_like_tree
+from fortuna.utils.nested_dicts import nested_get, nested_set
 
 
-class LaplacePosterior(Posterior):
+class LaplacePosterior(GaussianPosterior):
     def __init__(
         self,
         joint: Joint,

--- a/fortuna/prob_model/posterior/normalizing_flow/advi/advi_approximator.py
+++ b/fortuna/prob_model/posterior/normalizing_flow/advi/advi_approximator.py
@@ -1,5 +1,6 @@
 from fortuna.prob_model.posterior.base import PosteriorApproximator
 from fortuna.prob_model.posterior.normalizing_flow.advi import ADVI_NAME
+from typing import Optional, Tuple, List
 
 
 class ADVIPosteriorApproximator(PosteriorApproximator):
@@ -8,6 +9,7 @@ class ADVIPosteriorApproximator(PosteriorApproximator):
         std_init_params: float = 0.1,
         std_base: float = 0.1,
         n_loss_samples: int = 3,
+        which_params: Optional[Tuple[List, ...]] = None
     ):
         """
         Automatic Differentiation Variational Inference (ADVI) approximator. It is responsible to define how the
@@ -22,10 +24,21 @@ class ADVIPosteriorApproximator(PosteriorApproximator):
             distribution is assumed to be an isotropic Gaussian, with this argument as standard deviation.
         n_loss_samples : int
             Number of samples to approximate the loss, that is the KL divergence (or the ELBO, equivalently).
+        which_params: Optional[Tuple[List, ...]]
+            Sequences of keys to the parameters of the probabilistic model for which to define the Laplace
+            approximation. If `which_params` is not available, the Laplace approximation will be over all parameters.
         """
         self.std_init_params = std_init_params
         self.std_base = std_base
         self.n_loss_samples = n_loss_samples
+
+        if which_params:
+            if type(which_params) != tuple:
+                raise ValueError("`which_params` must be a tuple of lists.")
+            for list_keys in which_params:
+                if type(list_keys) != list:
+                    raise ValueError("Each element in `which_params` must be a list.")
+        self.which_params = which_params
 
     def __str__(self):
         return ADVI_NAME

--- a/fortuna/prob_model/posterior/normalizing_flow/advi/advi_approximator.py
+++ b/fortuna/prob_model/posterior/normalizing_flow/advi/advi_approximator.py
@@ -33,10 +33,10 @@ class ADVIPosteriorApproximator(PosteriorApproximator):
         self.n_loss_samples = n_loss_samples
 
         if which_params:
-            if type(which_params) != tuple:
+            if not isinstance(which_params, tuple):
                 raise ValueError("`which_params` must be a tuple of lists.")
             for list_keys in which_params:
-                if type(list_keys) != list:
+                if not isinstance(list_keys, list):
                     raise ValueError("Each element in `which_params` must be a list.")
         self.which_params = which_params
 

--- a/fortuna/prob_model/posterior/normalizing_flow/advi/advi_approximator.py
+++ b/fortuna/prob_model/posterior/normalizing_flow/advi/advi_approximator.py
@@ -26,7 +26,7 @@ class ADVIPosteriorApproximator(PosteriorApproximator):
             Number of samples to approximate the loss, that is the KL divergence (or the ELBO, equivalently).
         which_params: Optional[Tuple[List, ...]]
             Sequences of keys to the parameters of the probabilistic model for which to define the Laplace
-            approximation. If `which_params` is not available, the Laplace approximation will be over all parameters.
+            approximation. If `which_params` is not available, the posterior approximation will be over all parameters.
         """
         self.std_init_params = std_init_params
         self.std_base = std_base

--- a/fortuna/prob_model/posterior/normalizing_flow/advi/advi_posterior.py
+++ b/fortuna/prob_model/posterior/normalizing_flow/advi/advi_posterior.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, Tuple
+from typing import Optional, List
 
 import jax.numpy as jnp
 from flax.core import FrozenDict
 from jax._src.prng import PRNGKeyArray
 from jax.flatten_util import ravel_pytree
 
-from fortuna.data.loader import DataLoader, InputsLoader
+from fortuna.data.loader import DataLoader
 from fortuna.distribution.gaussian import DiagGaussian
 from fortuna.prob_model.fit_config.base import FitConfig
 from fortuna.prob_model.joint.base import Joint
@@ -26,8 +26,12 @@ from fortuna.prob_model.posterior.normalizing_flow.advi.advi_trainer import \
 from fortuna.prob_model.posterior.posterior_state_repository import \
     PosteriorStateRepository
 from fortuna.training.trainer import JittedMixin, MultiDeviceMixin
-from fortuna.typing import Array, Status
+from fortuna.typing import Status
 from fortuna.utils.device import select_trainer_given_devices
+from fortuna.prob_model.posterior.map.map_state import MAPState
+from fortuna.utils.nested_dicts import nested_get, nested_unpair
+from fortuna.prob_model.posterior.map.map_posterior import MAPPosterior
+from fortuna.prob_model.posterior.map.map_approximator import MAPPosteriorApproximator
 
 
 class JittedADVITrainer(JittedMixin, ADVITrainer):
@@ -63,6 +67,7 @@ class ADVIPosterior(Posterior):
         self,
         train_data_loader: DataLoader,
         val_data_loader: Optional[DataLoader] = None,
+        map_fit_config: Optional[FitConfig] = None,
         fit_config: FitConfig = FitConfig(),
         **kwargs,
     ) -> Status:
@@ -74,11 +79,71 @@ class ADVIPosterior(Posterior):
                 "`save_checkpoint_dir` must be passed when `dump_state` is set to True."
             )
 
-        init_prob_model_state, n_train_data, n_val_data = self._init(
-            train_data_loader, val_data_loader
+        state = None
+        stds = None
+        allowed_states = [MAPState, ADVIState]
+        status = dict()
+
+        if fit_config.checkpointer.restore_checkpoint_path is not None:
+            state = self.restore_checkpoint(
+                restore_checkpoint_path=fit_config.checkpointer.restore_checkpoint_path,
+                optimizer=fit_config.optimizer.method,
+            )
+
+            if type(state) not in allowed_states:
+                raise ValueError(f"The type of the restored checkpoint must be within {allowed_states}. "
+                                 f"However, {fit_config.checkpointer.restore_checkpoint_path} pointed to a state "
+                                 f"with type {type(state)}.")
+
+            if type(state) == ADVIState:
+                means, stds = nested_unpair(
+                    state.params.unfreeze(),
+                    self.posterior_approximator.which_params,
+                    ("mean", "std")
+                ) if self.posterior_approximator.which_params is not None else \
+                    [FrozenDict({k: dict(params=v["params"][s]) for k, v in state.params.items()}) for s in ["mean", "std"]]
+                means, stds = FrozenDict(means), FrozenDict(stds)
+                state = state.replace(params=means)
+                del means
+        elif map_fit_config is not None:
+            map_posterior = MAPPosterior(
+                self.joint, posterior_approximator=MAPPosteriorApproximator()
+            )
+            map_posterior.rng = self.rng
+            logging.info("Do a preliminary run of MAP.")
+            status["map"] = map_posterior.fit(
+                rng=self.rng.get(),
+                train_data_loader=train_data_loader,
+                val_data_loader=val_data_loader,
+                fit_config=map_fit_config,
+                **kwargs,
+            )
+            logging.info("Preliminary run with MAP completed.")
+            state = map_posterior.state.get()
+
+        state, n_train_data, n_val_data = self._init(
+            train_data_loader, val_data_loader, state
         )
 
-        rav, self.unravel = ravel_pytree(init_prob_model_state.params)
+        if self.posterior_approximator.which_params is None:
+            rav, self._unravel = ravel_pytree(state.params)
+            rav_stds = ravel_pytree(stds)[0] if stds is not None else None
+        else:
+            def unravel_fn(_params, _path):
+                return ravel_pytree(nested_get(_params, _path))
+            rav, self._unravel, sizes, rav_stds = [], [], [], []
+            for path in self.posterior_approximator.which_params:
+                _rav, _unravel = unravel_fn(state.params, path)
+                self._unravel.append(_unravel)
+                rav.append(_rav)
+                if stds is not None:
+                    rav_stds.append(unravel_fn(stds, path)[0])
+                sizes.append(len(_rav))
+            rav = jnp.concatenate(rav)
+            if stds is not None:
+                rav_stds = jnp.concatenate(rav_stds)
+            self._unravel = tuple(self._unravel)
+
         size_rav = len(rav)
         self.base = DiagGaussian(
             mean=jnp.zeros(size_rav),
@@ -108,35 +173,30 @@ class ADVIPosterior(Posterior):
             early_stopping_patience=fit_config.monitor.early_stopping_patience,
             base=self.base,
             architecture=self.architecture,
+            which_params=self.posterior_approximator.which_params,
+            all_params=state.params if self.posterior_approximator.which_params else None,
+            sizes=sizes if self.posterior_approximator.which_params else None,
+            unravel=self._unravel
         )
 
-        state = None
-        if fit_config.checkpointer.restore_checkpoint_path:
-            state = self.restore_checkpoint(
-                restore_checkpoint_path=fit_config.checkpointer.restore_checkpoint_path,
-                optimizer=fit_config.optimizer.method,
-            )
+        state = ADVIState.init(
+            FrozenDict(
+                zip(
+                    ("mean", "logvar"),
+                    trainer.init_params(
+                        self.rng.get(),
+                        mean=rav
+                    ) if stds is None else (rav, 2 * jnp.log(rav_stds)),
+                )
+            ),
+            getattr(state, "mutable", state.mutable),
+            fit_config.optimizer.method,
+            getattr(state, "calib_params", state.calib_params),
+            getattr(state, "calib_mutable", state.calib_mutable),
+        )
 
-        if type(state) != ADVIState:
-            state = ADVIState.init(
-                FrozenDict(
-                    zip(
-                        ("mean", "logvar"),
-                        trainer.init_params(
-                            self.rng.get(),
-                            mean=ravel_pytree(
-                                getattr(state, "params", init_prob_model_state.params)
-                            )[0],
-                        ),
-                    )
-                ),
-                getattr(state, "mutable", init_prob_model_state.mutable),
-                fit_config.optimizer.method,
-                getattr(state, "calib_params", init_prob_model_state.calib_params),
-                getattr(state, "calib_mutable", init_prob_model_state.calib_mutable),
-            )
         logging.info("Run ADVI.")
-        state, status = trainer.train(
+        state, status["advi"] = trainer.train(
             rng=self.rng.get(),
             state=state,
             loss_fun=self.joint._batched_negative_log_joint_prob,
@@ -147,10 +207,12 @@ class ADVIPosterior(Posterior):
             validation_dataloader=val_data_loader,
             validation_dataset_size=n_val_data,
             verbose=fit_config.monitor.verbose,
-            unravel=self.unravel,
+            unravel=self._unravel,
             n_samples=self.posterior_approximator.n_loss_samples,
             callbacks=fit_config.callbacks,
         )
+        trainer._all_params = None
+
         self.state = PosteriorStateRepository(
             fit_config.checkpointer.save_checkpoint_dir
             if fit_config.checkpointer.dump_state is True
@@ -163,66 +225,6 @@ class ADVIPosterior(Posterior):
     def sample(
         self,
         rng: Optional[PRNGKeyArray] = None,
-        input_shape: Optional[Tuple[int, ...]] = None,
-        inputs_loader: Optional[InputsLoader] = None,
-        inputs: Optional[Array] = None,
         **kwargs,
     ) -> JointState:
-        """
-        Sample from the posterior distribution. Either `input_shape` or `_inputs_loader` must be passed.
-
-        Parameters
-        ----------
-        rng : Optional[PRNGKeyArray]
-            A random number generator. If not passed, this will be taken from the attributes of this class.
-        input_shape: Optional[Tuple[int, ...]]
-            Shape of a single input.
-        inputs_loader: Optional[InputsLoader]
-            Input data loader. If `input_shape` is passed, then `inputs` and `inputs_loader` are ignored.
-        inputs: Optional[Array]
-            Input variables.
-
-        Returns
-        -------
-        JointState
-            A sample from the posterior distribution.
-        """
-        if rng is None:
-            rng = self.rng.get()
-        state = self.state.get()
-        state = state.replace(params=tuple(state.params.values()))
-        n_params = len(state.params[0])
-        if not hasattr(self, "base"):
-            self.base = DiagGaussian(
-                mean=jnp.zeros(n_params),
-                std=self.posterior_approximator.std_base * jnp.ones(n_params),
-            )
-        if not hasattr(self, "architecture"):
-            self.architecture = ADVIArchitecture(
-                n_params, std_init_params=self.posterior_approximator.std_init_params
-            )
-
-        if not hasattr(self, "unravel"):
-            if input_shape is None:
-                if inputs is not None:
-                    input_shape = inputs.shape[1:]
-                else:
-                    if inputs_loader is None:
-                        raise ValueError(
-                            "Either `input_shape` or `inputs_loader` or `inputs` must be passed."
-                        )
-                    for x in inputs_loader:
-                        input_shape = x.shape[1:]
-                        break
-            model_manager_state = self.joint.likelihood.model_manager.init(input_shape)
-            self.unravel = ravel_pytree(model_manager_state.params)[1]
-        sample_params = self.unravel(
-            self.architecture.forward(state.params, self.base.sample(rng))[0][0]
-        )
-
-        return JointState(
-            params=FrozenDict(sample_params),
-            mutable=state.mutable,
-            calib_params=state.calib_params,
-            calib_mutable=state.calib_mutable,
-        )
+        return self._sample_diag_gaussian(rng=rng, **kwargs)

--- a/fortuna/prob_model/posterior/normalizing_flow/advi/advi_trainer.py
+++ b/fortuna/prob_model/posterior/normalizing_flow/advi/advi_trainer.py
@@ -1,8 +1,65 @@
 from fortuna.prob_model.posterior.normalizing_flow.advi import ADVI_NAME
 from fortuna.prob_model.posterior.normalizing_flow.normalizing_flow_trainer import \
     NormalizingFlowTrainer
+from fortuna.utils.nested_dicts import nested_set, nested_pair
+from fortuna.prob_model.posterior.normalizing_flow.advi.advi_state import ADVIState
+from fortuna.typing import Path, Array, Params
+from typing import Optional, List
+import jax.numpy as jnp
+from flax.core import FrozenDict
 
 
 class ADVITrainer(NormalizingFlowTrainer):
     def __str__(self):
         return ADVI_NAME
+
+    def save_checkpoint(
+            self,
+            state: ADVIState,
+            save_checkpoint_dir: Path,
+            keep: int = 1,
+            force_save: bool = False,
+            prefix: str = "checkpoint_",
+    ) -> None:
+        state = state.replace(params=self._get_mean_std_from_rav_mean_logvar(state.params, self._all_params))
+        super().save_checkpoint(
+            state,
+            save_checkpoint_dir,
+            keep,
+            force_save,
+            prefix
+        )
+
+    def _get_mean_std_from_rav_mean_logvar(
+            self,
+            mean_logvar_rav: FrozenDict,
+            all_params: Optional[Params] = None,
+    ) -> Params:
+        if self._which_params is not None:
+            means = tuple([_unravel(mean_logvar_rav["mean"][self._idx[i]:self._idx[i + 1]]) for i, _unravel in enumerate(self._unravel)])
+            stds = tuple([_unravel(jnp.exp(0.5 * mean_logvar_rav["logvar"][self._idx[i]:self._idx[i + 1]])) for i, _unravel in enumerate(self._unravel)])
+
+            all_params = all_params.unfreeze()
+            all_params = nested_set(all_params, self._which_params, means)
+            all_params = nested_pair(
+                all_params,
+                self._which_params,
+                stds,
+                ("mean", "std"),
+            )
+            return FrozenDict(all_params)
+
+        params = self._unravel(mean_logvar_rav["mean"]).unfreeze()
+        stds = self._unravel(jnp.exp(0.5 * mean_logvar_rav["logvar"]))
+        for k, v in params.items():
+            params[k] = {"params": dict(mean=v["params"], std=stds[k]["params"])}
+        return FrozenDict(params)
+
+    def on_train_end(self, state: ADVIState) -> ADVIState:
+        self.save_checkpoint(
+            state,
+            save_checkpoint_dir=self.save_checkpoint_dir,
+            keep=self.keep_top_n_checkpoints,
+            force_save=True,
+        )
+        return state.replace(params=self._get_mean_std_from_rav_mean_logvar(state.params, self._all_params))

--- a/fortuna/prob_model/posterior/normalizing_flow/normalizing_flow_trainer.py
+++ b/fortuna/prob_model/posterior/normalizing_flow/normalizing_flow_trainer.py
@@ -215,8 +215,8 @@ class NormalizingFlowTrainer(PosteriorTrainerABC):
             return unravel(_rav)
         return FrozenDict(
             nested_set(
-                self._all_params.unfreeze(),
-                self._which_params,
-                tuple([_unravel(_rav[self._idx[i]:self._idx[i+1]]) for i, _unravel in enumerate(unravel)]),
+                d=self._all_params.unfreeze(),
+                key_paths=self._which_params,
+                objs=tuple([_unravel(_rav[self._idx[i]:self._idx[i+1]]) for i, _unravel in enumerate(unravel)]),
             )
         )

--- a/tests/fortuna/prob_model/test_train.py
+++ b/tests/fortuna/prob_model/test_train.py
@@ -359,6 +359,88 @@ class TestApproximations(unittest.TestCase):
                 calib_config=self.reg_calib_config_nodir_nodump,
             )
 
+            # now use which params
+            prob_reg = ProbRegressor(
+                model=MyModel(self.reg_output_dim),
+                likelihood_log_variance_model=MyModel(self.reg_output_dim),
+                posterior_approximator=ADVIPosteriorApproximator(
+                    which_params=(["model", "params", "l1", "bias"], ["model", "params", "l2", "kernel"])
+                ),
+                output_calibrator=RegressionTemperatureScaler(),
+            )
+            # no save dir, no dump
+            status = prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                fit_config=self.reg_fit_config_nodir_nodump,
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+            sample = prob_reg.posterior.sample()
+
+            # no save dir but dump
+            with self.assertRaises(ValueError):
+                status = prob_reg.train(
+                    train_data_loader=self.reg_train_data_loader,
+                    calib_data_loader=self.reg_val_data_loader,
+                    val_data_loader=self.reg_val_data_loader,
+                    fit_config=self.reg_fit_config_nodir_dump,
+                    calib_config=self.reg_calib_config_nodir_nodump,
+                )
+
+            # save dir, no dump
+            status = prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                fit_config=self.reg_fit_config_dir_nodump(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+            sample = prob_reg.posterior.sample()
+            prob_reg.posterior.load_state(tmp_dir)
+
+            # save dir and dump
+            status = prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                fit_config=self.reg_fit_config_dir_nodump(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+            sample = prob_reg.posterior.sample()
+            prob_reg.posterior.load_state(tmp_dir)
+
+            # restore from advi
+            prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                fit_config=self.reg_fit_config_restore(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+
+            #now use which params
+            prob_reg_map = ProbRegressor(
+                model=MyModel(self.reg_output_dim),
+                likelihood_log_variance_model=MyModel(self.reg_output_dim),
+                posterior_approximator=MAPPosteriorApproximator(),
+                output_calibrator=RegressionTemperatureScaler(),
+            )
+            status = prob_reg_map.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                fit_config=self.reg_fit_config_dir_dump(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+            prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                fit_config=self.reg_fit_config_restore(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+
             # load state
             prob_reg.load_state(checkpoint_path=tmp_dir)
 
@@ -370,6 +452,91 @@ class TestApproximations(unittest.TestCase):
             prob_class = ProbClassifier(
                 model=MyModel(self.class_output_dim),
                 posterior_approximator=ADVIPosteriorApproximator(),
+                output_calibrator=ClassificationTemperatureScaler(),
+            )
+            # no save dir, no dump
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                fit_config=self.class_fit_config_nodir_nodump,
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+            sample = prob_class.posterior.sample()
+
+            # no save dir but dump
+            with self.assertRaises(ValueError):
+                status = prob_class.train(
+                    train_data_loader=self.class_train_data_loader,
+                    calib_data_loader=self.class_val_data_loader,
+                    val_data_loader=self.class_val_data_loader,
+                    fit_config=self.class_fit_config_nodir_dump,
+                    calib_config=self.class_calib_config_nodir_nodump,
+                )
+
+            # save dir, no dump
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                fit_config=self.class_fit_config_dir_nodump(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+            sample = prob_class.posterior.sample()
+            prob_class.posterior.load_state(tmp_dir)
+
+            # save dir and dump
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                fit_config=self.class_fit_config_dir_dump(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+            sample = prob_class.posterior.sample()
+            prob_class.posterior.load_state(tmp_dir)
+
+            # restore from advi
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                fit_config=self.class_fit_config_restore(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+
+            # restore from map
+            prob_class_map = ProbClassifier(
+                model=MyModel(self.class_output_dim),
+                posterior_approximator=MAPPosteriorApproximator(),
+                output_calibrator=ClassificationTemperatureScaler(),
+            )
+            status = prob_class_map.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                fit_config=self.class_fit_config_dir_dump(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                fit_config=self.class_fit_config_restore(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+
+            # load state
+            prob_class.load_state(checkpoint_path=tmp_dir)
+
+            # save state
+            prob_class.save_state(checkpoint_path=tmp_dir)
+
+            # now use which params
+            prob_class = ProbClassifier(
+                model=MyModel(self.class_output_dim),
+                posterior_approximator=ADVIPosteriorApproximator(
+                    which_params=(["model", "params", "l1", "bias"], ["model", "params", "l2", "kernel"])),
                 output_calibrator=ClassificationTemperatureScaler(),
             )
             # no save dir, no dump
@@ -667,6 +834,95 @@ class TestApproximations(unittest.TestCase):
                 calib_config=self.reg_calib_config_nodir_nodump,
             )
 
+            # now with which params
+            prob_reg = ProbRegressor(
+                model=MyModel(self.reg_output_dim),
+                likelihood_log_variance_model=MyModel(self.reg_output_dim),
+                posterior_approximator=LaplacePosteriorApproximator(
+                    which_params=(["model", "params", "l1", "bias"], ["model", "params", "l2", "kernel"])
+                ),
+                output_calibrator=RegressionTemperatureScaler(),
+            )
+            # no save dir, no dump
+            status = prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                map_fit_config=self.reg_fit_config_nodir_nodump,
+                fit_config=self.reg_fit_config_nodir_nodump,
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+            sample = prob_reg.posterior.sample()
+
+            # no save dir but dump
+            with self.assertRaises(ValueError):
+                status = prob_reg.train(
+                    train_data_loader=self.reg_train_data_loader,
+                    calib_data_loader=self.reg_val_data_loader,
+                    val_data_loader=self.reg_val_data_loader,
+                    map_fit_config=self.reg_fit_config_nodir_nodump,
+                    fit_config=self.reg_fit_config_nodir_dump,
+                    calib_config=self.reg_calib_config_nodir_nodump,
+                )
+
+            # save dir, no dump
+            status = prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                map_fit_config=self.reg_fit_config_nodir_nodump,
+                fit_config=self.reg_fit_config_dir_nodump(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+            sample = prob_reg.posterior.sample()
+            prob_reg.posterior.load_state(tmp_dir)
+
+            # save dir and dump
+            status = prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                map_fit_config=self.reg_fit_config_nodir_nodump,
+                fit_config=self.reg_fit_config_dir_dump(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+            sample = prob_reg.posterior.sample()
+            prob_reg.posterior.load_state(tmp_dir)
+
+            # restore from laplace
+            prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                map_fit_config=self.reg_fit_config_nodir_nodump,
+                fit_config=self.reg_fit_config_restore(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+
+            # restore from map
+            prob_reg_map = ProbRegressor(
+                model=MyModel(self.reg_output_dim),
+                likelihood_log_variance_model=MyModel(self.reg_output_dim),
+                posterior_approximator=MAPPosteriorApproximator(),
+                output_calibrator=RegressionTemperatureScaler(),
+            )
+            status = prob_reg_map.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                map_fit_config=self.reg_fit_config_nodir_nodump,
+                fit_config=self.reg_fit_config_dir_dump(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+            status = prob_reg.train(
+                train_data_loader=self.reg_train_data_loader,
+                calib_data_loader=self.reg_val_data_loader,
+                val_data_loader=self.reg_val_data_loader,
+                map_fit_config=self.reg_fit_config_nodir_nodump,
+                fit_config=self.reg_fit_config_restore(tmp_dir),
+                calib_config=self.reg_calib_config_nodir_nodump,
+            )
+
             # load state
             prob_reg.load_state(checkpoint_path=tmp_dir)
 
@@ -678,6 +934,93 @@ class TestApproximations(unittest.TestCase):
             prob_class = ProbClassifier(
                 model=MyModel(self.class_output_dim),
                 posterior_approximator=LaplacePosteriorApproximator(),
+                output_calibrator=ClassificationTemperatureScaler(),
+            )
+            # no save dir, no dump
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                map_fit_config=self.class_fit_config_nodir_nodump,
+                fit_config=self.class_fit_config_nodir_nodump,
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+            sample = prob_class.posterior.sample()
+
+            # no save dir but dump
+            with self.assertRaises(ValueError):
+                status = prob_class.train(
+                    train_data_loader=self.class_train_data_loader,
+                    calib_data_loader=self.class_val_data_loader,
+                    val_data_loader=self.class_val_data_loader,
+                    map_fit_config=self.class_fit_config_nodir_nodump,
+                    fit_config=self.class_fit_config_nodir_dump,
+                    calib_config=self.class_calib_config_nodir_nodump,
+                )
+
+            # save dir, no dump
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                map_fit_config=self.class_fit_config_nodir_nodump,
+                fit_config=self.class_fit_config_dir_nodump(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+            sample = prob_class.posterior.sample()
+            prob_class.posterior.load_state(tmp_dir)
+
+            # save dir and dump
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                map_fit_config=self.class_fit_config_nodir_nodump,
+                fit_config=self.class_fit_config_dir_dump(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+            sample = prob_class.posterior.sample()
+            prob_class.posterior.load_state(tmp_dir)
+
+            # restore from laplace
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                map_fit_config=self.class_fit_config_nodir_nodump,
+                fit_config=self.class_fit_config_restore(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+
+            # restore from map
+            prob_class_map = ProbClassifier(
+                model=MyModel(self.class_output_dim),
+                posterior_approximator=MAPPosteriorApproximator(),
+                output_calibrator=ClassificationTemperatureScaler(),
+            )
+            status = prob_class_map.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                map_fit_config=self.class_fit_config_nodir_nodump,
+                fit_config=self.class_fit_config_dir_dump(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+            status = prob_class.train(
+                train_data_loader=self.class_train_data_loader,
+                calib_data_loader=self.class_val_data_loader,
+                val_data_loader=self.class_val_data_loader,
+                map_fit_config=self.class_fit_config_nodir_nodump,
+                fit_config=self.class_fit_config_restore(tmp_dir),
+                calib_config=self.class_calib_config_nodir_nodump,
+            )
+
+            # now with which params
+            prob_class = ProbClassifier(
+                model=MyModel(self.class_output_dim),
+                posterior_approximator=LaplacePosteriorApproximator(
+                    which_params=(["model", "params", "l1", "bias"], ["model", "params", "l2", "kernel"])
+                ),
                 output_calibrator=ClassificationTemperatureScaler(),
             )
             # no save dir, no dump


### PR DESCRIPTION
Similarly to what already available for the Laplace approximation, we want to allow to run ADVI on any subsets of model parameters. This drastically increases the scalability of the method over large models.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

ADVI is necessarily run over all model parameters.

Issue Number: N/A

## What is the new behavior?

The user can configure a `which_params` argument in the `ADVIPosteriorApproximator`, including a tuple of paths (i.e. list of strings) pointing to the parameter that ADVI will be applied upon.
