### PR TITLE
reduce computation of example notebooks

### DIFF
--- a/examples/enbpi_ts_regression.pct.py
+++ b/examples/enbpi_ts_regression.pct.py
@@ -48,7 +48,9 @@ _ = ax.set(
 
 # %%
 from sklearn.model_selection import train_test_split
+import numpy as np
 
+df = df.sample(1000)
 y = df["count"] / df["count"].max()
 X = df.drop("count", axis="columns")
 X_train, X_test = train_test_split(X, test_size=0.1, shuffle=False)
@@ -61,9 +63,6 @@ y_train, y_test = train_test_split(y, test_size=0.1, shuffle=False)
 # EnbPI requires bootstrapping the data, i.e. sampling with replacement random subsets of the time series and training a model for each of these samples.
 
 # %%
-import numpy as np
-
-
 class DataFrameBootstrapper:
     def __init__(self, n_samples: int):
         self.n_samples = n_samples

--- a/examples/jackknifeplus_regression.pct.py
+++ b/examples/jackknifeplus_regression.pct.py
@@ -29,9 +29,9 @@
 from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
 
-X, y = make_regression(n_samples=2000, n_features=3, n_targets=1)
+X, y = make_regression(n_samples=500, n_features=3, n_targets=1)
 X_train, X_test, y_train, y_test = train_test_split(
-    X, y, random_state=0, test_size=1000
+    X, y, random_state=0, test_size=250
 )
 
 # %% [markdown]

--- a/examples/mnist_classification.pct.py
+++ b/examples/mnist_classification.pct.py
@@ -78,7 +78,7 @@ prob_model = ProbClassifier(
 # We can now train the probabilistic model. This includes fitting the posterior distribution and calibrating the probabilistic model. As we are using a Laplace approximation, which start from a Maximum-A-Posteriori (MAP) approximation, we configure MAP via the argument `map_fit_config`.
 
 # %%
-from fortuna.prob_model import FitConfig, FitMonitor
+from fortuna.prob_model import FitConfig, FitMonitor, CalibConfig, CalibMonitor
 from fortuna.metric.classification import accuracy
 
 status = prob_model.train(
@@ -88,6 +88,7 @@ status = prob_model.train(
     map_fit_config=FitConfig(
         monitor=FitMonitor(early_stopping_patience=2, metrics=(accuracy,))
     ),
+    calib_config=CalibConfig(monitor=CalibMonitor(early_stopping_patience=2))
 )
 
 
@@ -189,9 +190,7 @@ test_targets = test_data_loader.to_array_targets()
 from fortuna.output_calib_model import OutputCalibClassifier
 
 calib_model = OutputCalibClassifier()
-calib_status = calib_model.calibrate(
-    calib_outputs=calib_outputs, calib_targets=calib_targets
-)
+calib_status = calib_model.calibrate(calib_outputs=calib_outputs, calib_targets=calib_targets)
 
 # %% [markdown] pycharm={"name": "#%% md\n"}
 # Similarly as above, we can now compute predictive statistics.

--- a/examples/multivalid_coverage.pct.py
+++ b/examples/multivalid_coverage.pct.py
@@ -72,9 +72,9 @@ def plot_intervals(xx, means, intervals, test_data, method):
 # Let us first generate training, calibration and test data points.
 
 # %%
-train_data = generate_data(10000)
-calib_data = generate_data(1000)
-test_data = generate_data(1000)
+train_data = generate_data(500)
+calib_data = generate_data(500)
+test_data = generate_data(500)
 
 # %% [markdown]
 # We then plot the training data. We see that when $x<0$ the data is much less noisy than when $x>0$.
@@ -124,11 +124,14 @@ idx_left, idx_right = [group_fns[i](test_data[0]) for i in range(2)]
 # We start by training a probabilistic classifier based on a MultiLayer Perceptron (MLP) model. Under the hood, posterior inference is performed by SWAG [Maddox W. J. et al., 2019](https://proceedings.neurips.cc/paper/2019/hash/118921efba23fc329e6560b27861f0c2-Abstract.html).
 
 # %%
-from fortuna.prob_model import ProbRegressor
+from fortuna.prob_model import ProbRegressor, FitConfig, FitMonitor
 from fortuna.model import MLP
 
 prob_model = ProbRegressor(model=MLP(1), likelihood_log_variance_model=MLP(1))
-status = prob_model.train(train_data_loader)
+status = prob_model.train(
+    train_data_loader,
+    map_fit_config=FitConfig(monitor=FitMonitor(early_stopping_patience=2))
+)
 
 # %% [markdown]
 # We then compute predictive mean and 95% credible intervals, and we measure marginal coverage on the full domain and on each of the two groups. We notice that the method tend to undercover overall and also on each group, compared to the desired coverage of 95%. Better hyper-parameter configurations and generating more samples to compute statistics may help achieve a better coverage already, but for the purpose of this example we will directly look at how to calibrate it with conformal prediction methods.

--- a/examples/sinusoidal_regression.pct.py
+++ b/examples/sinusoidal_regression.pct.py
@@ -38,9 +38,9 @@ def make_sinusoidal(n_data: int, noise: float = 0.1, seed: int = 0):
     return x[:, None], y[:, None]
 
 
-train_data = make_sinusoidal(n_data=10000, seed=0)
-val_data = make_sinusoidal(n_data=1000, seed=1)
-test_data = make_sinusoidal(n_data=1000, seed=2)
+train_data = make_sinusoidal(n_data=500, seed=0)
+val_data = make_sinusoidal(n_data=500, seed=1)
+test_data = make_sinusoidal(n_data=500, seed=2)
 
 fig, axes = plt.subplots(1, 3, figsize=(10, 1))
 axes[0].scatter(*train_data, s=1, label="training data", c="C0")
@@ -86,7 +86,7 @@ prob_model = ProbRegressor(
 # We can now train the probabilistic model. This includes fitting the posterior distribution and calibrating the probabilistic model.
 
 # %%
-from fortuna.prob_model import FitConfig, FitMonitor
+from fortuna.prob_model import FitConfig, FitMonitor, CalibConfig, CalibMonitor
 from fortuna.metric.regression import rmse
 
 status = prob_model.train(
@@ -94,6 +94,7 @@ status = prob_model.train(
     val_data_loader=val_data_loader,
     calib_data_loader=val_data_loader,
     fit_config=FitConfig(monitor=FitMonitor(early_stopping_patience=2, metrics=(rmse,))),
+    calib_config=CalibConfig(monitor=CalibMonitor(early_stopping_patience=2))
 )
 
 # %%
@@ -242,15 +243,17 @@ test_targets = test_data_loader.to_array_targets()
 # We now invoke a calibration classifier, with default temperature scaling output calibrator, and calibrate the model outputs.
 
 # %% pycharm={"name": "#%%\n"}
-from fortuna.output_calib_model import OutputCalibRegressor
+from fortuna.output_calib_model import OutputCalibRegressor, Config, Monitor
 
 calib_model = OutputCalibRegressor()
 calib_status = calib_model.calibrate(
-    calib_outputs=calib_outputs, calib_targets=calib_targets
+    calib_outputs=calib_outputs,
+    calib_targets=calib_targets,
+    config=Config(monitor=Monitor(early_stopping_patience=2))
 )
 
 
-# %% [markdown]
+# %% [markdown] d
 # Similarly as above, we can now compute predictive statistics.
 
 # %% pycharm={"name": "#%%\n"}

--- a/examples/subnet_calibration.pct.py
+++ b/examples/subnet_calibration.pct.py
@@ -27,7 +27,7 @@ import tensorflow_datasets as tfds
 
 def download(split_range, shuffle=False):
     ds = tfds.load(
-        name="mnist_corrupted",
+        name="mnist",
         split=f"train[{split_range}]",
         as_supervised=True,
         shuffle_files=True,

--- a/examples/two_moons_classification_sngp.pct.py
+++ b/examples/two_moons_classification_sngp.pct.py
@@ -27,7 +27,7 @@
 
 # %%
 
-TRAIN_DATA_SIZE = 2000
+TRAIN_DATA_SIZE = 500
 
 from sklearn.datasets import make_moons
 train_data = make_moons(n_samples=TRAIN_DATA_SIZE, noise=0.1, random_state=0)
@@ -83,7 +83,7 @@ output_dim = 2
 model = DeepResidualNet(
     output_dim=output_dim,
     activations=(nn.relu, nn.relu, nn.relu, nn.relu, nn.relu, nn.relu),
-    widths=(128,128,128,128,128,128),
+    widths=(128, 128, 128, 128, 128, 128),
     dropout_rate=0.1,
 )
 
@@ -142,8 +142,6 @@ class SNGPDeepFeatureExtractorSubNet(WithSpectralNorm, DeepResidualFeatureExtrac
 # - Using the `SNGPPosteriorApproximator` as the `posterior_approximator` for the `ProbModel`.
 #
 # Nothing else is needed, Fortuna will take care of the rest for you!
-#
-# %%
 
 # %%
 import jax.numpy as jnp
@@ -171,13 +169,9 @@ prob_model = ProbClassifier(
 # `output_dim`, which should be set to the number of classes in the classification task.
 # `SNGPPosteriorApproximator` has more optional parameters that you can play with, to gain a better understanding of those you can
 # check out the documentation and/or the [original paper](https://arxiv.org/abs/2006.10108).
-#
-# %%
 
 # %% [markdown]
 # We are now ready to train the model as we usually do:
-#
-# %%
 
 # %%
 status = prob_model.train(


### PR DESCRIPTION
ReadTheDocs builds are going out of time limit, presumably because the notebooks are compiled at every build to ensure they work. Here we reduce the computational time to execute each notebook.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):