### PR TITLE
Minor consistency fix: `checkpoint_path` -> `checkpoint_dir`

### DIFF
--- a/fortuna/calib_model/base.py
+++ b/fortuna/calib_model/base.py
@@ -121,30 +121,30 @@ class CalibModel(WithCalibCheckpointingMixin, abc.ABC):
             logging.info("Calibration completed.")
         return status
 
-    def load_state(self, checkpoint_path: Path) -> None:
+    def load_state(self, checkpoint_dir: Path) -> None:
         """
         Load the state of the posterior distribution from a checkpoint path. The checkpoint must be compatible with the
         probabilistic model.
 
         Parameters
         ----------
-        checkpoint_path : Path
+        checkpoint_dir : Path
             Path to a checkpoint file or directory to restore.
         """
         try:
-            self.restore_checkpoint(checkpoint_path)
+            self.restore_checkpoint(checkpoint_dir)
         except ValueError:
             raise ValueError(
-                f"No checkpoint was found in `checkpoint_path={checkpoint_path}`."
+                f"No checkpoint was found in `checkpoint_dir={checkpoint_dir}`."
             )
-        self.predictive.state = CalibStateRepository(checkpoint_dir=checkpoint_path)
+        self.predictive.state = CalibStateRepository(checkpoint_dir=checkpoint_dir)
 
     def save_state(
-        self, checkpoint_path: Path, keep_top_n_checkpoints: int = 1
+        self, checkpoint_dir: Path, keep_top_n_checkpoints: int = 1
     ) -> None:
         return self.predictive.state.put(
             self.predictive.state.get(),
-            checkpoint_path=checkpoint_path,
+            checkpoint_dir=checkpoint_dir,
             keep=keep_top_n_checkpoints,
         )
 
@@ -179,7 +179,7 @@ class CalibModel(WithCalibCheckpointingMixin, abc.ABC):
         return CalibState.init(params=state.params, mutable=state.mutable, optimizer=config.optimizer.method)
 
     def _init_state(self, calib_data_loader: DataLoader, config: Config) -> CalibState:
-        if config.checkpointer.restore_checkpoint_path is None:
+        if config.checkpointer.restore_checkpoint_dir is None:
             if config.checkpointer.start_from_current_state:
                 state = self.predictive.state.get(optimizer=config.optimizer.method)
             else:
@@ -187,9 +187,9 @@ class CalibModel(WithCalibCheckpointingMixin, abc.ABC):
         else:
             if config.checkpointer.start_from_current_state:
                 logging.warning("`config.checkpointer.start_from_current_state` will be ignored since "
-                                "`config.checkpointer.restore_checkpoint_path` is given.")
+                                "`config.checkpointer.restore_checkpoint_dir` is given.")
             state = self.restore_checkpoint(
-                restore_checkpoint_path=config.checkpointer.restore_checkpoint_path,
+                restore_checkpoint_dir=config.checkpointer.restore_checkpoint_dir,
                 optimizer=config.optimizer.method,
             )
         return state

--- a/fortuna/calib_model/calib_mixin.py
+++ b/fortuna/calib_model/calib_mixin.py
@@ -9,19 +9,19 @@ from flax.training import checkpoints
 class WithCalibCheckpointingMixin(WithCheckpointingMixin):
     def restore_checkpoint(
         self,
-        restore_checkpoint_path: Path,
+        restore_checkpoint_dir: Path,
         optimizer: Optional[OptaxOptimizer] = None,
         prefix: str = "checkpoint_",
         **kwargs,
     ) -> CalibState:
-        if not os.path.isdir(restore_checkpoint_path) and not os.path.isfile(
-            restore_checkpoint_path
+        if not os.path.isdir(restore_checkpoint_dir) and not os.path.isfile(
+            restore_checkpoint_dir
         ):
             raise ValueError(
-                f"`restore_checkpoint_path={restore_checkpoint_path}` was not found."
+                f"`restore_checkpoint_dir={restore_checkpoint_dir}` was not found."
             )
         d = checkpoints.restore_checkpoint(
-            ckpt_dir=str(restore_checkpoint_path),
+            ckpt_dir=str(restore_checkpoint_dir),
             target=None,
             step=None,
             prefix=prefix,
@@ -29,7 +29,7 @@ class WithCalibCheckpointingMixin(WithCheckpointingMixin):
         )
         if d is None:
             raise ValueError(
-                f"No checkpoint was found in `restore_checkpoint_path={restore_checkpoint_path}`."
+                f"No checkpoint was found in `restore_checkpoint_dir={restore_checkpoint_dir}`."
             )
 
         return CalibState.init_from_dict(d, optimizer, **kwargs)

--- a/fortuna/calib_model/config/checkpointer.py
+++ b/fortuna/calib_model/config/checkpointer.py
@@ -7,7 +7,7 @@ class Checkpointer:
     def __init__(
         self,
         save_checkpoint_dir: Optional[Path] = None,
-        restore_checkpoint_path: Optional[Path] = None,
+        restore_checkpoint_dir: Optional[Path] = None,
         start_from_current_state: bool = False,
         save_every_n_steps: Optional[int] = None,
         keep_top_n_checkpoints: Optional[int] = 2,
@@ -20,10 +20,10 @@ class Checkpointer:
         ----------
         save_checkpoint_dir: Optional[Path] = None
             Save directory location.
-        restore_checkpoint_path: Optional[Path]
+        restore_checkpoint_dir: Optional[Path]
             Path to checkpoint file or directory to restore.
         start_from_current_state: bool = False
-            If True, the optimization will start from the current state. If `restore_checkpoint_path` is given, then
+            If True, the optimization will start from the current state. If `restore_checkpoint_dir` is given, then
             `start_from_current_state` is ignored.
         save_every_n_steps: int
             Number of training steps between checkpoints. To disable, set `every_n_train_steps` to None or 0 (no
@@ -36,7 +36,7 @@ class Checkpointer:
         """
         self.save_checkpoint_dir = save_checkpoint_dir
         self.save_every_n_steps = save_every_n_steps
-        self.restore_checkpoint_path = restore_checkpoint_path
+        self.restore_checkpoint_dir = restore_checkpoint_dir
         self.start_from_current_state = start_from_current_state
         self.keep_top_n_checkpoints = keep_top_n_checkpoints
         self.dump_state = dump_state

--- a/fortuna/output_calib_model/base.py
+++ b/fortuna/output_calib_model/base.py
@@ -76,7 +76,7 @@ class OutputCalibModel(WithOutputCalibCheckpointingMixin, abc.ABC):
             early_stopping_patience=config.monitor.early_stopping_patience,
         )
 
-        if config.checkpointer.restore_checkpoint_path is None:
+        if config.checkpointer.restore_checkpoint_dir is None:
             state = OutputCalibManagerState.init_from_dict(
                 d=FrozenDict(
                     output_calibrator=self.output_calib_manager.init(
@@ -91,7 +91,7 @@ class OutputCalibModel(WithOutputCalibCheckpointingMixin, abc.ABC):
             )
         else:
             state = self.restore_checkpoint(
-                config.checkpointer.restore_checkpoint_path,
+                config.checkpointer.restore_checkpoint_dir,
                 optimizer=config.optimizer.method,
             )
 
@@ -119,33 +119,33 @@ class OutputCalibModel(WithOutputCalibCheckpointingMixin, abc.ABC):
         )
         return status
 
-    def load_state(self, checkpoint_path: Path) -> None:
+    def load_state(self, checkpoint_dir: Path) -> None:
         """
         Load a calibration state from a checkpoint path.
         The checkpoint must be compatible with the calibration model.
 
         Parameters
         ----------
-        checkpoint_path : Path
+        checkpoint_dir : Path
             Path to a checkpoint file or directory to restore.
         """
         try:
-            self.restore_checkpoint(checkpoint_path)
+            self.restore_checkpoint(checkpoint_dir)
         except ValueError:
             raise ValueError(
-                f"No checkpoint was found in `checkpoint_path={checkpoint_path}`."
+                f"No checkpoint was found in `checkpoint_dir={checkpoint_dir}`."
             )
-        self.predictive.state = OutputCalibStateRepository(checkpoint_dir=checkpoint_path)
+        self.predictive.state = OutputCalibStateRepository(checkpoint_dir=checkpoint_dir)
 
     def save_state(
-        self, checkpoint_path: Path, keep_top_n_checkpoints: int = 1
+        self, checkpoint_dir: Path, keep_top_n_checkpoints: int = 1
     ) -> None:
         """
         Save the calibration state as a checkpoint.
 
         Parameters
         ----------
-        checkpoint_path : Path
+        checkpoint_dir : Path
             Path to file or directory where to save the current state.
         keep_top_n_checkpoints : int
             Number of past checkpoint files to keep.
@@ -156,6 +156,6 @@ class OutputCalibModel(WithOutputCalibCheckpointingMixin, abc.ABC):
             )
         return self.predictive.state.put(
             self.predictive.state.get(),
-            checkpoint_path=checkpoint_path,
+            checkpoint_dir=checkpoint_dir,
             keep=keep_top_n_checkpoints,
         )

--- a/fortuna/output_calib_model/config/checkpointer.py
+++ b/fortuna/output_calib_model/config/checkpointer.py
@@ -7,7 +7,7 @@ class Checkpointer:
     def __init__(
         self,
         save_checkpoint_dir: Optional[Path] = None,
-        restore_checkpoint_path: Optional[Path] = None,
+        restore_checkpoint_dir: Optional[Path] = None,
         save_every_n_steps: Optional[int] = None,
         keep_top_n_checkpoints: Optional[int] = 2,
         dump_state: bool = False,
@@ -19,7 +19,7 @@ class Checkpointer:
         ----------
         save_checkpoint_dir: Optional[Path] = None
             Save directory location.
-        restore_checkpoint_path: Optional[Path]
+        restore_checkpoint_dir: Optional[Path]
             Path to checkpoint file or directory to restore.
         save_every_n_steps: int
             Number of training steps between checkpoints. To disable, set `every_n_train_steps` to None or 0 (no
@@ -32,6 +32,6 @@ class Checkpointer:
         """
         self.save_checkpoint_dir = save_checkpoint_dir
         self.save_every_n_steps = save_every_n_steps
-        self.restore_checkpoint_path = restore_checkpoint_path
+        self.restore_checkpoint_dir = restore_checkpoint_dir
         self.keep_top_n_checkpoints = keep_top_n_checkpoints
         self.dump_state = dump_state

--- a/fortuna/output_calib_model/output_calib_mixin.py
+++ b/fortuna/output_calib_model/output_calib_mixin.py
@@ -9,19 +9,19 @@ from flax.training import checkpoints
 class WithOutputCalibCheckpointingMixin(WithCheckpointingMixin):
     def restore_checkpoint(
         self,
-        restore_checkpoint_path: Path,
+        restore_checkpoint_dir: Path,
         optimizer: Optional[OptaxOptimizer] = None,
         prefix: str = "checkpoint_",
         **kwargs,
     ) -> OutputCalibState:
-        if not os.path.isdir(restore_checkpoint_path) and not os.path.isfile(
-            restore_checkpoint_path
+        if not os.path.isdir(restore_checkpoint_dir) and not os.path.isfile(
+            restore_checkpoint_dir
         ):
             raise ValueError(
-                f"`restore_checkpoint_path={restore_checkpoint_path}` was not found."
+                f"`restore_checkpoint_dir={restore_checkpoint_dir}` was not found."
             )
         d = checkpoints.restore_checkpoint(
-            ckpt_dir=str(restore_checkpoint_path),
+            ckpt_dir=str(restore_checkpoint_dir),
             target=None,
             step=None,
             prefix=prefix,
@@ -29,7 +29,7 @@ class WithOutputCalibCheckpointingMixin(WithCheckpointingMixin):
         )
         if d is None:
             raise ValueError(
-                f"No checkpoint was found in `restore_checkpoint_path={restore_checkpoint_path}`."
+                f"No checkpoint was found in `restore_checkpoint_dir={restore_checkpoint_dir}`."
             )
 
         return OutputCalibState.init_from_dict(d, optimizer, **kwargs)

--- a/fortuna/prob_model/base.py
+++ b/fortuna/prob_model/base.py
@@ -173,7 +173,7 @@ class ProbModel(abc.ABC):
                 early_stopping_patience=calib_config.monitor.early_stopping_patience,
             )
 
-            if calib_config.checkpointer.restore_checkpoint_path is None:
+            if calib_config.checkpointer.restore_checkpoint_dir is None:
                 calib_dict = self.posterior.state.extract_calib_keys()
 
                 state = OutputCalibState.init(
@@ -183,7 +183,7 @@ class ProbModel(abc.ABC):
                 )
             else:
                 state = self.posterior.restore_checkpoint(
-                    calib_config.checkpointer.restore_checkpoint_path,
+                    calib_config.checkpointer.restore_checkpoint_dir,
                     optimizer=calib_config.optimizer.method,
                 )
 
@@ -213,7 +213,7 @@ class ProbModel(abc.ABC):
                 if calib_config.monitor.verbose:
                     logging.info("Dump state to disk.")
                 self.save_state(
-                    checkpoint_path=calib_config.checkpointer.save_checkpoint_dir
+                    checkpoint_dir=calib_config.checkpointer.save_checkpoint_dir
                 )
 
             if calib_config.monitor.verbose:
@@ -221,29 +221,29 @@ class ProbModel(abc.ABC):
 
             return status
 
-    def load_state(self, checkpoint_path: Path) -> None:
+    def load_state(self, checkpoint_dir: Path) -> None:
         """
         Load the state of the posterior distribution from a checkpoint path. The checkpoint must be compatible with the
         probabilistic model.
 
         Parameters
         ----------
-        checkpoint_path : Path
+        checkpoint_dir : Path
             Path to a checkpoint file or directory to restore.
         """
-        return self.posterior.load_state(checkpoint_path)
+        return self.posterior.load_state(checkpoint_dir)
 
     def save_state(
-        self, checkpoint_path: Path, keep_top_n_checkpoints: int = 1
+        self, checkpoint_dir: Path, keep_top_n_checkpoints: int = 1
     ) -> None:
         """
         Save the posterior distribution state as a checkpoint.
 
         Parameters
         ----------
-        checkpoint_path : Path
+        checkpoint_dir : Path
             Path to file or directory where to save the current state.
         keep_top_n_checkpoints : int
             Number of past checkpoint files to keep.
         """
-        return self.posterior.save_state(checkpoint_path, keep_top_n_checkpoints)
+        return self.posterior.save_state(checkpoint_dir, keep_top_n_checkpoints)

--- a/fortuna/prob_model/calib_config/checkpointer.py
+++ b/fortuna/prob_model/calib_config/checkpointer.py
@@ -7,7 +7,7 @@ class CalibCheckpointer:
     def __init__(
         self,
         save_checkpoint_dir: Optional[Path] = None,
-        restore_checkpoint_path: Optional[Path] = None,
+        restore_checkpoint_dir: Optional[Path] = None,
         save_every_n_steps: Optional[int] = None,
         keep_top_n_checkpoints: Optional[int] = 2,
         dump_state: bool = False,
@@ -19,7 +19,7 @@ class CalibCheckpointer:
         ----------
         save_checkpoint_dir: Optional[Path] = None
             Save directory location.
-        restore_checkpoint_path: Optional[Path]
+        restore_checkpoint_dir: Optional[Path]
             Path to checkpoint file or directory to restore.
         save_every_n_steps: int
             Number of training steps between checkpoints. To disable, set `every_n_train_steps` to None or 0 (no
@@ -32,6 +32,6 @@ class CalibCheckpointer:
         """
         self.save_checkpoint_dir = save_checkpoint_dir
         self.save_every_n_steps = save_every_n_steps
-        self.restore_checkpoint_path = restore_checkpoint_path
+        self.restore_checkpoint_dir = restore_checkpoint_dir
         self.keep_top_n_checkpoints = keep_top_n_checkpoints
         self.dump_state = dump_state

--- a/fortuna/prob_model/fit_config/checkpointer.py
+++ b/fortuna/prob_model/fit_config/checkpointer.py
@@ -7,7 +7,7 @@ class FitCheckpointer:
     def __init__(
         self,
         save_checkpoint_dir: Optional[Path] = None,
-        restore_checkpoint_path: Optional[Path] = None,
+        restore_checkpoint_dir: Optional[Path] = None,
         save_every_n_steps: Optional[int] = None,
         keep_top_n_checkpoints: Optional[int] = 2,
         dump_state: bool = False,
@@ -19,7 +19,7 @@ class FitCheckpointer:
         ----------
         save_checkpoint_dir: Optional[Path]
             Save directory location.
-        restore_checkpoint_path: Optional[Path]
+        restore_checkpoint_dir: Optional[Path]
             Path to checkpoint file or directory to restore.
         save_every_n_steps: int
             Number of training steps between checkpoints. To disable, set `every_n_train_steps` to None or 0 (no
@@ -32,6 +32,6 @@ class FitCheckpointer:
         """
         self.save_checkpoint_dir = save_checkpoint_dir
         self.save_every_n_steps = save_every_n_steps
-        self.restore_checkpoint_path = restore_checkpoint_path
+        self.restore_checkpoint_dir = restore_checkpoint_dir
         self.keep_top_n_checkpoints = keep_top_n_checkpoints
         self.dump_state = dump_state

--- a/fortuna/prob_model/posterior/base.py
+++ b/fortuna/prob_model/posterior/base.py
@@ -121,33 +121,33 @@ class Posterior(WithRNG, WithPosteriorCheckpointingMixin):
         """
         pass
 
-    def load_state(self, checkpoint_path: Path) -> None:
+    def load_state(self, checkpoint_dir: Path) -> None:
         """
         Load the state of the posterior distribution from a checkpoint path. The checkpoint must be
         compatible with the current probabilistic model.
 
         Parameters
         ----------
-        checkpoint_path: Path
+        checkpoint_dir: Path
             Path to checkpoint file or directory to restore.
         """
         try:
-            self.restore_checkpoint(checkpoint_path)
+            self.restore_checkpoint(checkpoint_dir)
         except ValueError:
             raise ValueError(
-                f"No checkpoint was found in `checkpoint_path={checkpoint_path}`."
+                f"No checkpoint was found in `checkpoint_dir={checkpoint_dir}`."
             )
-        self.state = PosteriorStateRepository(checkpoint_dir=checkpoint_path)
+        self.state = PosteriorStateRepository(checkpoint_dir=checkpoint_dir)
 
     def save_state(
-        self, checkpoint_path: Path, keep_top_n_checkpoints: int = 1
+        self, checkpoint_dir: Path, keep_top_n_checkpoints: int = 1
     ) -> None:
         """
         Save the state of the posterior distribution to a checkpoint directory.
 
         Parameters
         ----------
-        checkpoint_path: Path
+        checkpoint_dir: Path
             Path to checkpoint file or directory to restore.
         keep_top_n_checkpoints: int
             Number of past checkpoint files to keep.
@@ -159,6 +159,6 @@ class Posterior(WithRNG, WithPosteriorCheckpointingMixin):
             )
         return self.state.put(
             self.state.get(),
-            checkpoint_path=checkpoint_path,
+            checkpoint_dir=checkpoint_dir,
             keep=keep_top_n_checkpoints,
         )

--- a/fortuna/prob_model/posterior/deep_ensemble/deep_ensemble_posterior.py
+++ b/fortuna/prob_model/posterior/deep_ensemble/deep_ensemble_posterior.py
@@ -93,10 +93,10 @@ class DeepEnsemblePosterior(Posterior):
                 early_stopping_patience=fit_config.monitor.early_stopping_patience,
             )
 
-            if fit_config.checkpointer.restore_checkpoint_path:
+            if fit_config.checkpointer.restore_checkpoint_dir:
                 state = self.restore_checkpoint(
-                    restore_checkpoint_path=str(
-                        fit_config.checkpointer.restore_checkpoint_path
+                    restore_checkpoint_dir=str(
+                        fit_config.checkpointer.restore_checkpoint_dir
                     )
                     + "/"
                     + str(i),

--- a/fortuna/prob_model/posterior/deep_ensemble/deep_ensemble_repositories.py
+++ b/fortuna/prob_model/posterior/deep_ensemble/deep_ensemble_repositories.py
@@ -24,14 +24,14 @@ class DeepEnsemblePosteriorStateRepository:
     def get(
         self,
         i: int = None,
-        checkpoint_path: Optional[Path] = None,
+        checkpoint_dir: Optional[Path] = None,
         optimizer: Optional[OptaxOptimizer] = None,
         prefix: str = "checkpoint_",
         **kwargs
     ) -> Union[List[PosteriorState], PosteriorState]:
         def _get(_i):
             return self.state[_i].get(
-                checkpoint_path=checkpoint_path,
+                checkpoint_dir=checkpoint_dir,
                 optimizer=optimizer,
                 prefix=prefix,
                 **kwargs
@@ -48,13 +48,13 @@ class DeepEnsemblePosteriorStateRepository:
         self,
         state: PosteriorState,
         i: int = None,
-        checkpoint_path: Optional[Path] = None,
+        checkpoint_dir: Optional[Path] = None,
         keep: int = 1,
         prefix: str = "checkpoint_",
     ) -> None:
         def _put(_i):
             return self.state[_i].put(
-                state=state, checkpoint_path=checkpoint_path, keep=keep, prefix=prefix
+                state=state, checkpoint_dir=checkpoint_dir, keep=keep, prefix=prefix
             )
 
         if i is not None:
@@ -66,14 +66,14 @@ class DeepEnsemblePosteriorStateRepository:
     def pull(
         self,
         i: int = None,
-        checkpoint_path: Path = None,
+        checkpoint_dir: Path = None,
         optimizer: Optional[OptaxOptimizer] = None,
         prefix: str = "checkpoint_",
         **kwargs
     ) -> Union[DeepEnsembleState, PosteriorState]:
         def _pull(_i):
             return self.state[_i].pull(
-                checkpoint_path=checkpoint_path,
+                checkpoint_dir=checkpoint_dir,
                 optimizer=optimizer,
                 prefix=prefix,
                 **kwargs
@@ -90,7 +90,7 @@ class DeepEnsemblePosteriorStateRepository:
         self,
         variables: Dict,
         i: int = None,
-        checkpoint_path: Path = None,
+        checkpoint_dir: Path = None,
         optimizer: Optional[OptaxOptimizer] = None,
         keep: int = 1,
         prefix: str = "checkpoint_",
@@ -99,7 +99,7 @@ class DeepEnsemblePosteriorStateRepository:
         def _update(_i):
             self.state[_i].update(
                 variables=variables,
-                checkpoint_path=checkpoint_path,
+                checkpoint_dir=checkpoint_dir,
                 optimizer=optimizer,
                 keep=keep,
                 prefix=prefix,
@@ -116,13 +116,13 @@ class DeepEnsemblePosteriorStateRepository:
         self,
         keys: List[str],
         i: int = None,
-        checkpoint_path: Optional[Path] = None,
+        checkpoint_dir: Optional[Path] = None,
         prefix: str = "checkpoint_",
         **kwargs
     ) -> Union[Dict, List[Dict]]:
         def _extract(_i):
             return self.state[_i].extract(
-                keys=keys, checkpoint_path=checkpoint_path, prefix=prefix, **kwargs
+                keys=keys, checkpoint_dir=checkpoint_dir, prefix=prefix, **kwargs
             )
 
         if i is not None:
@@ -134,10 +134,10 @@ class DeepEnsemblePosteriorStateRepository:
 
     def extract_calib_keys(
         self,
-        checkpoint_path: Optional[Path] = None,
+        checkpoint_dir: Optional[Path] = None,
         prefix: str = "checkpoint_",
         **kwargs
     ) -> Dict:
         return self.extract(
-            ["calib_params", "calib_mutable"], 0, checkpoint_path, prefix, **kwargs
+            ["calib_params", "calib_mutable"], 0, checkpoint_dir, prefix, **kwargs
         )

--- a/fortuna/prob_model/posterior/laplace/laplace_posterior.py
+++ b/fortuna/prob_model/posterior/laplace/laplace_posterior.py
@@ -198,7 +198,7 @@ class LaplacePosterior(GaussianPosterior):
 
         status = {}
 
-        if not fit_config.checkpointer.restore_checkpoint_path:
+        if not fit_config.checkpointer.restore_checkpoint_dir:
             map_posterior = MAPPosterior(
                 self.joint, posterior_approximator=MAPPosteriorApproximator()
             )
@@ -217,7 +217,7 @@ class LaplacePosterior(GaussianPosterior):
             state = map_posterior.state.get()
         else:
             state = self.restore_checkpoint(
-                restore_checkpoint_path=fit_config.checkpointer.restore_checkpoint_path
+                restore_checkpoint_dir=fit_config.checkpointer.restore_checkpoint_dir
             )
 
         if type(state) == MAPState:

--- a/fortuna/prob_model/posterior/map/map_posterior.py
+++ b/fortuna/prob_model/posterior/map/map_posterior.py
@@ -83,9 +83,9 @@ class MAPPosterior(Posterior):
             early_stopping_patience=fit_config.monitor.early_stopping_patience,
         )
 
-        if fit_config.checkpointer.restore_checkpoint_path:
+        if fit_config.checkpointer.restore_checkpoint_dir:
             state = self.restore_checkpoint(
-                restore_checkpoint_path=fit_config.checkpointer.restore_checkpoint_path,
+                restore_checkpoint_dir=fit_config.checkpointer.restore_checkpoint_dir,
                 optimizer=fit_config.optimizer.method,
             )
         else:

--- a/fortuna/prob_model/posterior/normalizing_flow/advi/advi_posterior.py
+++ b/fortuna/prob_model/posterior/normalizing_flow/advi/advi_posterior.py
@@ -206,15 +206,15 @@ class ADVIPosterior(GaussianPosterior):
         state = None
         status = dict()
 
-        if fit_config.checkpointer.restore_checkpoint_path is not None:
+        if fit_config.checkpointer.restore_checkpoint_dir is not None:
             state = self.restore_checkpoint(
-                restore_checkpoint_path=fit_config.checkpointer.restore_checkpoint_path,
+                restore_checkpoint_dir=fit_config.checkpointer.restore_checkpoint_dir,
                 optimizer=fit_config.optimizer.method,
             )
 
             if not isinstance(state, allowed_states):
                 raise ValueError(f"The type of the restored checkpoint must be within {allowed_states}. "
-                                 f"However, {fit_config.checkpointer.restore_checkpoint_path} pointed to a state "
+                                 f"However, {fit_config.checkpointer.restore_checkpoint_dir} pointed to a state "
                                  f"with type {type(state)}.")
 
             if isinstance(state, ADVIState):

--- a/fortuna/prob_model/posterior/posterior_mixin.py
+++ b/fortuna/prob_model/posterior/posterior_mixin.py
@@ -10,14 +10,14 @@ from fortuna.typing import OptaxOptimizer, Path
 class WithPosteriorCheckpointingMixin(WithCheckpointingMixin):
     def restore_checkpoint(
         self,
-        restore_checkpoint_path: Path,
+        restore_checkpoint_dir: Path,
         optimizer: Optional[OptaxOptimizer] = None,
         prefix: str = "checkpoint_",
         name_to_train_state: NameToPosteriorState = NameToPosteriorState,
         **kwargs,
     ) -> PosteriorState:
         return super().restore_checkpoint(
-            restore_checkpoint_path,
+            restore_checkpoint_dir,
             optimizer,
             prefix,
             name_to_train_state=name_to_train_state,

--- a/fortuna/prob_model/posterior/posterior_state_repository.py
+++ b/fortuna/prob_model/posterior/posterior_state_repository.py
@@ -9,10 +9,10 @@ from fortuna.typing import Path
 class PosteriorStateRepository(WithPosteriorCheckpointingMixin, TrainStateRepository):
     def extract_calib_keys(
         self,
-        checkpoint_path: Optional[Path] = None,
+        checkpoint_dir: Optional[Path] = None,
         prefix: str = "checkpoint_",
         **kwargs
     ) -> Dict:
         return super().extract(
-            ["calib_params", "calib_mutable"], checkpoint_path, prefix, **kwargs
+            ["calib_params", "calib_mutable"], checkpoint_dir, prefix, **kwargs
         )

--- a/fortuna/prob_model/posterior/swag/swag_posterior.py
+++ b/fortuna/prob_model/posterior/swag/swag_posterior.py
@@ -87,7 +87,7 @@ class SWAGPosterior(Posterior):
 
         status = {}
 
-        if not fit_config.checkpointer.restore_checkpoint_path:
+        if not fit_config.checkpointer.restore_checkpoint_dir:
             map_posterior = MAPPosterior(
                 self.joint, posterior_approximator=MAPPosteriorApproximator()
             )
@@ -107,7 +107,7 @@ class SWAGPosterior(Posterior):
             logging.info("Preliminary run with MAP completed.")
         else:
             state = self.restore_checkpoint(
-                restore_checkpoint_path=fit_config.checkpointer.restore_checkpoint_path,
+                restore_checkpoint_dir=fit_config.checkpointer.restore_checkpoint_dir,
                 optimizer=fit_config.optimizer.method,
             )
             if type(state) == MAPState:

--- a/fortuna/training/mixin.py
+++ b/fortuna/training/mixin.py
@@ -43,20 +43,20 @@ class WithCheckpointingMixin:
 
     def restore_checkpoint(
         self,
-        restore_checkpoint_path: Path,
+        restore_checkpoint_dir: Path,
         optimizer: Optional[OptaxOptimizer] = None,
         prefix: str = "checkpoint_",
         name_to_train_state: NameToTrainState = NameToTrainState,
         **kwargs,
     ) -> TrainState:
-        if not os.path.isdir(restore_checkpoint_path) and not os.path.isfile(
-            restore_checkpoint_path
+        if not os.path.isdir(restore_checkpoint_dir) and not os.path.isfile(
+            restore_checkpoint_dir
         ):
             raise ValueError(
-                f"`restore_checkpoint_path={restore_checkpoint_path}` was not found."
+                f"`restore_checkpoint_dir={restore_checkpoint_dir}` was not found."
             )
         d = checkpoints.restore_checkpoint(
-            ckpt_dir=str(restore_checkpoint_path),
+            ckpt_dir=str(restore_checkpoint_dir),
             target=None,
             step=None,
             prefix=prefix,
@@ -64,7 +64,7 @@ class WithCheckpointingMixin:
         )
         if d is None:
             raise ValueError(
-                f"No checkpoint was found in `restore_checkpoint_path={restore_checkpoint_path}`."
+                f"No checkpoint was found in `restore_checkpoint_dir={restore_checkpoint_dir}`."
             )
         name = "".join([chr(n) for n in d["encoded_name"].tolist()])
         return name_to_train_state[name].value.init_from_dict(d, optimizer, **kwargs)

--- a/fortuna/training/train_state_repository.py
+++ b/fortuna/training/train_state_repository.py
@@ -15,16 +15,16 @@ class TrainStateRepository(WithCheckpointingMixin):
 
     def get(
         self,
-        checkpoint_path: Optional[Path] = None,
+        checkpoint_dir: Optional[Path] = None,
         optimizer: Optional[OptaxOptimizer] = None,
         prefix: str = "checkpoint_",
         **kwargs
     ) -> Union[Dict, TrainState]:
-        if not checkpoint_path and not self.checkpoint_dir and not self.__state:
+        if not checkpoint_dir and not self.checkpoint_dir and not self.__state:
             raise ValueError("No state available.")
-        if checkpoint_path or self.checkpoint_dir:
+        if checkpoint_dir or self.checkpoint_dir:
             return self.restore_checkpoint(
-                restore_checkpoint_path=checkpoint_path or self.checkpoint_dir,
+                restore_checkpoint_dir=checkpoint_dir or self.checkpoint_dir,
                 optimizer=optimizer,
                 prefix=prefix,
                 **kwargs
@@ -37,14 +37,14 @@ class TrainStateRepository(WithCheckpointingMixin):
     def put(
         self,
         state: TrainState,
-        checkpoint_path: Optional[Path] = None,
+        checkpoint_dir: Optional[Path] = None,
         keep: int = 1,
         prefix: str = "checkpoint_",
     ) -> None:
-        if checkpoint_path or self.checkpoint_dir:
+        if checkpoint_dir or self.checkpoint_dir:
             self.save_checkpoint(
                 state=state,
-                save_checkpoint_dir=checkpoint_path or self.checkpoint_dir,
+                save_checkpoint_dir=checkpoint_dir or self.checkpoint_dir,
                 keep=keep,
                 force_save=True,
                 prefix=prefix,
@@ -54,20 +54,20 @@ class TrainStateRepository(WithCheckpointingMixin):
 
     def pull(
         self,
-        checkpoint_path: Path = None,
+        checkpoint_dir: Path = None,
         optimizer: Optional[OptaxOptimizer] = None,
         prefix: str = "checkpoint_",
         **kwargs
     ) -> TrainState:
         state = self.get(
-            checkpoint_path=checkpoint_path,
+            checkpoint_dir=checkpoint_dir,
             optimizer=optimizer,
             prefix=prefix,
             **kwargs
         )
-        if checkpoint_path or self.checkpoint_dir:
+        if checkpoint_dir or self.checkpoint_dir:
             os.remove(
-                checkpoint_path
+                checkpoint_dir
                 or self.get_path_latest_checkpoint(self.checkpoint_dir, prefix=prefix)
             )
         return state
@@ -75,27 +75,27 @@ class TrainStateRepository(WithCheckpointingMixin):
     def update(
         self,
         variables: Dict,
-        checkpoint_path: Path = None,
+        checkpoint_dir: Path = None,
         optimizer: Optional[OptaxOptimizer] = None,
         keep: int = 1,
         prefix: str = "checkpoint_",
         **kwargs
     ):
         state = self.pull(
-            checkpoint_path=checkpoint_path,
+            checkpoint_dir=checkpoint_dir,
             optimizer=optimizer,
             prefix=prefix,
             **kwargs
         )
         state = state.replace(**variables)
-        self.put(state, checkpoint_path=checkpoint_path, keep=keep, prefix=prefix)
+        self.put(state, checkpoint_dir=checkpoint_dir, keep=keep, prefix=prefix)
 
     def extract(
         self,
         keys: List[str],
-        checkpoint_path: Optional[Path] = None,
+        checkpoint_dir: Optional[Path] = None,
         prefix: str = "checkpoint_",
         **kwargs
     ) -> Dict:
-        state = self.get(checkpoint_path=checkpoint_path, prefix=prefix, **kwargs)
+        state = self.get(checkpoint_dir=checkpoint_dir, prefix=prefix, **kwargs)
         return {k: getattr(state, k) for k in keys}

--- a/tests/fortuna/calib_model/test_calib_model.py
+++ b/tests/fortuna/calib_model/test_calib_model.py
@@ -99,7 +99,7 @@ class TestCalibCalibrate(unittest.TestCase):
         )
         self.class_config_restore = lambda restore_dir: Config(
             optimizer=Optimizer(n_epochs=3),
-            checkpointer=Checkpointer(restore_checkpoint_path=restore_dir),
+            checkpointer=Checkpointer(restore_checkpoint_dir=restore_dir),
         )
         self.reg_config_nodir_nodump = Config(
             optimizer=Optimizer(n_epochs=3), monitor=Monitor(metrics=(scaled_mse,))
@@ -121,7 +121,7 @@ class TestCalibCalibrate(unittest.TestCase):
         )
         self.reg_config_restore = lambda restore_dir: Config(
             optimizer=Optimizer(n_epochs=3),
-            checkpointer=Checkpointer(restore_checkpoint_path=restore_dir),
+            checkpointer=Checkpointer(restore_checkpoint_dir=restore_dir),
         )
 
     def test_dryrun_reg(self):
@@ -186,10 +186,10 @@ class TestCalibCalibrate(unittest.TestCase):
             )
 
             # load state
-            calib_reg.load_state(checkpoint_path=tmp_dir)
+            calib_reg.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            calib_reg.save_state(checkpoint_path=tmp_dir)
+            calib_reg.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_class(self):
         model = MLP(self.class_output_dim)
@@ -253,10 +253,10 @@ class TestCalibCalibrate(unittest.TestCase):
             )
 
             # load state
-            calib_class.load_state(checkpoint_path=tmp_dir)
+            calib_class.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            calib_class.save_state(checkpoint_path=tmp_dir)
+            calib_class.save_state(checkpoint_dir=tmp_dir)
 
     def test_error_when_empty_data_loader(self):
         calib_class_map = CalibClassifier(

--- a/tests/fortuna/calib_model/test_output_calib_model.py
+++ b/tests/fortuna/calib_model/test_output_calib_model.py
@@ -120,7 +120,7 @@ class TestApproximations(unittest.TestCase):
         self.calib_config_restore = lambda directory, metric: Config(
             optimizer=Optimizer(n_epochs=3),
             monitor=Monitor(metrics=(metric,)),
-            checkpointer=Checkpointer(restore_checkpoint_path=directory),
+            checkpointer=Checkpointer(restore_checkpoint_dir=directory),
         )
 
     def test_dryrun_reg_map(self):
@@ -175,10 +175,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            calib_model.load_state(checkpoint_path=tmp_dir)
+            calib_model.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            calib_model.save_state(checkpoint_path=tmp_dir)
+            calib_model.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_class_map(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -231,7 +231,7 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            calib_model.load_state(checkpoint_path=tmp_dir)
+            calib_model.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            calib_model.save_state(checkpoint_path=tmp_dir)
+            calib_model.save_state(checkpoint_dir=tmp_dir)

--- a/tests/fortuna/prob_model/test_train.py
+++ b/tests/fortuna/prob_model/test_train.py
@@ -118,7 +118,7 @@ class TestApproximations(unittest.TestCase):
         )
         self.class_fit_config_restore = lambda restore_dir: FitConfig(
             optimizer=FitOptimizer(n_epochs=3),
-            checkpointer=FitCheckpointer(restore_checkpoint_path=restore_dir),
+            checkpointer=FitCheckpointer(restore_checkpoint_dir=restore_dir),
         )
         self.reg_fit_config_nodir_nodump = FitConfig(
             optimizer=FitOptimizer(n_epochs=3), monitor=FitMonitor(metrics=(rmse,))
@@ -140,7 +140,7 @@ class TestApproximations(unittest.TestCase):
         )
         self.reg_fit_config_restore = lambda restore_dir: FitConfig(
             optimizer=FitOptimizer(n_epochs=3),
-            checkpointer=FitCheckpointer(restore_checkpoint_path=restore_dir),
+            checkpointer=FitCheckpointer(restore_checkpoint_dir=restore_dir),
         )
         self.class_calib_config_nodir_nodump = CalibConfig(
             optimizer=CalibOptimizer(n_epochs=3), monitor=CalibMonitor(metrics=(brier,))
@@ -209,10 +209,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_reg.load_state(checkpoint_path=tmp_dir)
+            prob_reg.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_reg.save_state(checkpoint_path=tmp_dir)
+            prob_reg.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_class_map(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -273,10 +273,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_class.load_state(checkpoint_path=tmp_dir)
+            prob_class.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_class.save_state(checkpoint_path=tmp_dir)
+            prob_class.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_reg_advi(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -442,10 +442,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_reg.load_state(checkpoint_path=tmp_dir)
+            prob_reg.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_reg.save_state(checkpoint_path=tmp_dir)
+            prob_reg.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_class_advi(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -527,10 +527,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_class.load_state(checkpoint_path=tmp_dir)
+            prob_class.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_class.save_state(checkpoint_path=tmp_dir)
+            prob_class.save_state(checkpoint_dir=tmp_dir)
 
             # now use which params
             prob_class = ProbClassifier(
@@ -612,10 +612,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_class.load_state(checkpoint_path=tmp_dir)
+            prob_class.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_class.save_state(checkpoint_path=tmp_dir)
+            prob_class.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_reg_deep_ensemble(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -677,10 +677,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_reg.load_state(checkpoint_path=tmp_dir)
+            prob_reg.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_reg.save_state(checkpoint_path=tmp_dir)
+            prob_reg.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_class_deep_ensemble(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -741,10 +741,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_class.load_state(checkpoint_path=tmp_dir)
+            prob_class.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_class.save_state(checkpoint_path=tmp_dir)
+            prob_class.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_reg_laplace(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -924,10 +924,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_reg.load_state(checkpoint_path=tmp_dir)
+            prob_reg.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_reg.save_state(checkpoint_path=tmp_dir)
+            prob_reg.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_class_laplace(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1103,10 +1103,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_class.load_state(checkpoint_path=tmp_dir)
+            prob_class.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_class.save_state(checkpoint_path=tmp_dir)
+            prob_class.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_reg_swag(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1197,10 +1197,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_reg.load_state(checkpoint_path=tmp_dir)
+            prob_reg.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_reg.save_state(checkpoint_path=tmp_dir)
+            prob_reg.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_class_swag(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1287,10 +1287,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_class.load_state(checkpoint_path=tmp_dir)
+            prob_class.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_class.save_state(checkpoint_path=tmp_dir)
+            prob_class.save_state(checkpoint_dir=tmp_dir)
 
     def test_dryrun_class_sngp_no_sn(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1372,10 +1372,10 @@ class TestApproximations(unittest.TestCase):
             )
 
             # load state
-            prob_class.load_state(checkpoint_path=tmp_dir)
+            prob_class.load_state(checkpoint_dir=tmp_dir)
 
             # save state
-            prob_class.save_state(checkpoint_path=tmp_dir)
+            prob_class.save_state(checkpoint_dir=tmp_dir)
 
     def test_error_when_empty_data_loader(self):
         prob_class_map = ProbClassifier(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- the API has been using `checkpoint_path` and `checkpoint_dir` in different places. E.g. `FitCheckpointer.save_checkpoint_dir` but `FitCheckpointer.restore_checkpoint_path`, etc.

## What is the new behavior?

- `checkpoint_dir` is used everywhere.
