### PR TITLE
reintroduce deterministic shuffling in data loaders

### DIFF
--- a/fortuna/data/loader/utils.py
+++ b/fortuna/data/loader/utils.py
@@ -56,10 +56,11 @@ class IterableData:
         return cls(_inner)
 
     @classmethod
-    def from_array_data(cls, data: Array, batch_size: Optional[int] = None, shuffle: bool = False,  prefetch: bool = False):
+    def from_array_data(cls, data: Array, batch_size: Optional[int] = None, shuffle: bool = False, prefetch: bool = False, seed: Optional[int] = 0):
             def _inner():
                 if shuffle:
-                    perm = np.random.choice(
+                    rng = np.random.default_rng(seed)
+                    perm = rng.choice(
                         data.shape[0], data.shape[0], replace=False
                     )
                 if batch_size is None:
@@ -79,10 +80,11 @@ class IterableData:
             return cls(_inner)
 
     @classmethod
-    def from_batch_array_data(cls, data: Tuple[Array, Array], batch_size: Optional[int] = None, shuffle: bool = False,  prefetch: bool = False):
+    def from_batch_array_data(cls, data: Tuple[Array, Array], batch_size: Optional[int] = None, shuffle: bool = False, prefetch: bool = False, seed: Optional[int] = 0):
             def _inner():
                 if shuffle:
-                    perm = np.random.choice(
+                    rng = np.random.default_rng(seed)
+                    perm = rng.choice(
                         data[0].shape[0], data[0].shape[0], replace=False
                     )
                 if batch_size is None:


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- `from_array_data` and `from_batch_array_data` produce new batches order after the recent refactoring.

## What is the new behavior?

- make shuffle ~~great~~ deterministic again.
