### PR TITLE
Enable prefetching on a single GPU at prediction time

### DIFF
--- a/fortuna/likelihood/base.py
+++ b/fortuna/likelihood/base.py
@@ -450,8 +450,6 @@ class Likelihood(WithRNG):
         jnp.ndarray
             The calibrated outputs.
         """
-        if distribute and jax.local_device_count() <= 1:
-            distribute = False
 
         if distribute:
             inputs_loader = DeviceDimensionAugmentedLoader(inputs_loader)
@@ -774,9 +772,6 @@ class Likelihood(WithRNG):
         distribute: bool = True,
         **kwargs
     ) -> Array:
-        if distribute and jax.local_device_count() <= 1:
-            distribute = False
-
         def fun2(_inputs):
             return fun(params, _inputs, mutable, calib_params, calib_mutable, **kwargs)
 
@@ -800,9 +795,6 @@ class Likelihood(WithRNG):
         distribute: bool = True,
         **kwargs
     ) -> Array:
-        if distribute and jax.local_device_count() <= 1:
-            distribute = False
-
         def fun2(_batch):
             return fun(params, _batch, mutable, calib_params, calib_mutable, **kwargs)
 

--- a/fortuna/prob_model/predictive/base.py
+++ b/fortuna/prob_model/predictive/base.py
@@ -267,7 +267,7 @@ class Predictive(WithRNG):
                         self.likelihood._unshard_array(fun(inputs))
                         for inputs in inputs_loader
                     ],
-                    0,
+                    1,
                 )
             else:
                 samples, aux_outputs = [], []

--- a/fortuna/prob_model/predictive/base.py
+++ b/fortuna/prob_model/predictive/base.py
@@ -253,9 +253,6 @@ class Predictive(WithRNG):
         if not rng:
             rng = self.rng.get()
 
-        if distribute and jax.local_device_count() <= 1:
-            distribute = False
-
         def fun(_inputs):
             return self._batched_sample(
                 _inputs, n_target_samples, return_aux, rng, **kwargs
@@ -445,9 +442,6 @@ class Predictive(WithRNG):
         if rng is None:
             rng = self.rng.get()
         keys = random.split(rng, n_output_samples)
-
-        if distribute and jax.local_device_count() <= 1:
-            distribute = False
 
         if distribute:
             inputs_loader = DeviceDimensionAugmentedLoader(inputs_loader)
@@ -855,9 +849,6 @@ class Predictive(WithRNG):
         distribute: bool = True,
         **kwargs
     ) -> Array:
-        if distribute and jax.local_device_count() <= 1:
-            distribute = False
-
         def fun2(_inputs):
             return fun(_inputs, n_posterior_samples, rng, **kwargs)
 
@@ -883,8 +874,6 @@ class Predictive(WithRNG):
         distribute: bool = True,
         **kwargs
     ) -> Array:
-        if distribute and jax.local_device_count() <= 1:
-            distribute = False
 
         def fun2(_batch):
             return fun(_batch, n_posterior_samples, rng, **kwargs)
@@ -908,8 +897,6 @@ class Predictive(WithRNG):
         distribute: bool = True,
         **kwargs
     ) -> Array:
-        if distribute and jax.local_device_count() <= 1:
-            distribute = False
 
         def fun2(_inputs):
             return fun(_inputs, n_posterior_samples, rng, **kwargs)


### PR DESCRIPTION

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On single GPU `DeviceDimensionAugmentedLoader` was not used. This does not allow to do prefetching. 

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Use `DeviceDimensionAugmentedLoader` also on a single GPU.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
