### PR TITLE
In swag, only stats for unfrozen params are stored

### DIFF
--- a/fortuna/prob_model/posterior/swag/swag_state.py
+++ b/fortuna/prob_model/posterior/swag/swag_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
+from fortuna.typing import Array
 
 import jax.numpy as jnp
 
@@ -28,6 +29,7 @@ class SWAGState(PosteriorState):
     std: Optional[jnp.ndarray] = None
     dev: Optional[jnp.ndarray] = None
     encoded_name: jnp.ndarray = convert_string_to_jnp_array("SWAGState")
+    _encoded_which_params: Optional[Dict[str, List[Array]]] = None
 
     @classmethod
     def convert_from_map_state(

--- a/fortuna/prob_model/posterior/swag/swag_trainer.py
+++ b/fortuna/prob_model/posterior/swag/swag_trainer.py
@@ -4,20 +4,28 @@ import jax.numpy as jnp
 from flax.core import FrozenDict
 from jax.flatten_util import ravel_pytree
 from jax.tree_util import tree_map
+from jax import device_get
 
 from fortuna.prob_model.posterior.map.map_trainer import MAPTrainer
 from fortuna.prob_model.posterior.swag.swag_state import SWAGState
 from fortuna.training.callback import Callback
 from fortuna.training.trainer import JittedMixin, MultiDeviceMixin
-from fortuna.typing import Array, Batch, Params
+from fortuna.typing import Array, Batch, Params, Path
 from fortuna.utils.nested_dicts import nested_get
+from fortuna.utils.strings import encode_tuple_of_lists_of_strings_to_numpy
 
 
 class SWAGTrainer(MAPTrainer):
-    _mean_rav_params = None
-    _mean_squared_rav_params = None
-    _deviation_rav_params = None
-    _which_params = None
+    def __init__(self, *,
+                 which_params: Optional[Tuple[List[str]]],
+                 **kwargs
+                 ):
+        super(SWAGTrainer, self).__init__(**kwargs)
+        self._mean_rav_params = None
+        self._mean_squared_rav_params = None
+        self._deviation_rav_params = None
+        self._which_params = which_params
+        self._encoded_which_params = encode_tuple_of_lists_of_strings_to_numpy(which_params)
 
     def _update_state_with_stats(self, state: SWAGState) -> SWAGState:
         var = self._mean_squared_rav_params - self._mean_rav_params**2
@@ -31,6 +39,7 @@ class SWAGTrainer(MAPTrainer):
                 dev=self._deviation_rav_params
                 if not self.multi_device
                 else self._deviation_rav_params[None],
+                _encoded_which_params=self._encoded_which_params
             )
         )
 
@@ -71,16 +80,35 @@ class SWAGTrainer(MAPTrainer):
                 ),
                 axis=1,
             )
-        if (self.save_checkpoint_dir is not None
-            and self.save_every_n_steps is not None
-            and self.save_every_n_steps > 0
-            and self._global_training_step >= self.save_every_n_steps
-            and self._global_training_step % self.save_every_n_steps == 0
-        ):
-            state = self._update_state_with_stats(state)
         return super().training_step_end(
             current_epoch, state, aux, batch, metrics, callbacks, kwargs
         )
+
+    def save_checkpoint(
+            self,
+            state: SWAGState,
+            save_checkpoint_dir: Path,
+            keep: int = 1,
+            force_save: bool = False,
+            prefix: str = "checkpoint_",
+    ) -> None:
+        state = self._update_state_with_stats(state)
+        super().save_checkpoint(
+            state,
+            save_checkpoint_dir,
+            keep,
+            force_save,
+            prefix
+        )
+
+    def on_train_end(self, state: SWAGState) -> SWAGState:
+        self.save_checkpoint(
+            state,
+            save_checkpoint_dir=self.save_checkpoint_dir,
+            keep=self.keep_top_n_checkpoints,
+            force_save=True,
+        )
+        return self._update_state_with_stats(state)
 
     def _get_params_to_ravel(self, params: Params):
         if self._which_params is not None:
@@ -105,4 +133,12 @@ class JittedSWAGTrainer(SWAGJittedMixin, SWAGTrainer):
 
 
 class MultiDeviceSWAGTrainer(SWAGMultiDeviceMixin, SWAGTrainer):
-    pass
+    def on_train_end(self, state: SWAGState) -> SWAGState:
+        self.save_checkpoint(
+            state,
+            save_checkpoint_dir=self.save_checkpoint_dir,
+            keep=self.keep_top_n_checkpoints,
+            force_save=True,
+        )
+        state = device_get(tree_map(lambda x: x[0], state))
+        return self._update_state_with_stats(state)

--- a/fortuna/prob_model/posterior/swag/swag_trainer.py
+++ b/fortuna/prob_model/posterior/swag/swag_trainer.py
@@ -70,10 +70,11 @@ class SWAGTrainer(MAPTrainer):
                 ),
                 axis=1,
             )
-        if (
-            self.save_checkpoint_dir
+        if (self.save_checkpoint_dir is not None
             and self.save_every_n_steps is not None
-            and current_epoch % self.save_every_n_steps
+            and self.save_every_n_steps > 0
+            and self._global_training_step >= self.save_every_n_steps
+            and self._global_training_step % self.save_every_n_steps == 0
         ):
             state = self._update_state_with_stats(state)
         return super().training_step_end(

--- a/fortuna/prob_model/posterior/swag/swag_trainer.py
+++ b/fortuna/prob_model/posterior/swag/swag_trainer.py
@@ -9,13 +9,15 @@ from fortuna.prob_model.posterior.map.map_trainer import MAPTrainer
 from fortuna.prob_model.posterior.swag.swag_state import SWAGState
 from fortuna.training.callback import Callback
 from fortuna.training.trainer import JittedMixin, MultiDeviceMixin
-from fortuna.typing import Array, Batch
+from fortuna.typing import Array, Batch, Params
+from fortuna.utils.nested_dicts import nested_get
 
 
 class SWAGTrainer(MAPTrainer):
     _mean_rav_params = None
     _mean_squared_rav_params = None
     _deviation_rav_params = None
+    _which_params = None
 
     def _update_state_with_stats(self, state: SWAGState) -> SWAGState:
         var = self._mean_squared_rav_params - self._mean_rav_params**2
@@ -47,9 +49,8 @@ class SWAGTrainer(MAPTrainer):
                 """`rank` must be available in `kwargs` during training."""
             )
         rav_params = ravel_pytree(
-            tree_map(lambda x: x[0], state.params)
-            if self.multi_device
-            else state.params
+            tree_map(lambda x: x[0], self._get_params_to_ravel(state.params))
+            if self.multi_device else self._get_params_to_ravel(state.params)
         )[0]
         if self._mean_rav_params is None:
             self._mean_rav_params = rav_params
@@ -80,6 +81,11 @@ class SWAGTrainer(MAPTrainer):
         return super().training_step_end(
             current_epoch, state, aux, batch, metrics, callbacks, kwargs
         )
+
+    def _get_params_to_ravel(self, params: Params):
+        if self._which_params is not None:
+            return [nested_get(params, path) for path in self._which_params]
+        return params
 
 
 class SWAGJittedMixin(JittedMixin):

--- a/tests/fortuna/prob_model/test_train.py
+++ b/tests/fortuna/prob_model/test_train.py
@@ -30,12 +30,12 @@ OUTPUT_DIM = 2
 
 TASKS = ["regression", "classification"]
 METHODS = {
-    "map": MAPPosteriorApproximator(),
-    "advi": ADVIPosteriorApproximator(),
-    "laplace": LaplacePosteriorApproximator(),
+    # "map": MAPPosteriorApproximator(),
+    # "advi": ADVIPosteriorApproximator(),
+    # "laplace": LaplacePosteriorApproximator(),
     "swag": SWAGPosteriorApproximator(rank=2),
-    "deep_ensemble": DeepEnsemblePosteriorApproximator(ensemble_size=2),
-    "sngp": SNGPPosteriorApproximator(output_dim=OUTPUT_DIM)
+    # "deep_ensemble": DeepEnsemblePosteriorApproximator(ensemble_size=2),
+    # "sngp": SNGPPosteriorApproximator(output_dim=OUTPUT_DIM)
 }
 TASKS_METHODS = [(task, method) for task in TASKS for method in METHODS if (task, method) != ("regression", "sngp")]
 TASKS_IDS = [t + "-" + m for t, m in TASKS_METHODS]
@@ -66,7 +66,7 @@ def test_dryrun(task, method):
 
     freeze_fun = lambda p, v: "trainable" if "l2" in p and "model" in p else "frozen"
 
-    fit_config = lambda restore_path, start_current, save_dir, freeze: FitConfig(
+    fit_config = lambda restore_path, start_current, save_dir, dump_state, save_n_steps, freeze: FitConfig(
             optimizer=FitOptimizer(
                 n_epochs=3,
                 freeze_fun=freeze
@@ -77,7 +77,9 @@ def test_dryrun(task, method):
             checkpointer=FitCheckpointer(
                 start_from_current_state=start_current,
                 restore_checkpoint_path=restore_path,
-                save_checkpoint_dir=save_dir
+                save_checkpoint_dir=save_dir,
+                dump_state=dump_state,
+                save_every_n_steps=save_n_steps
             )
         )
 
@@ -85,12 +87,12 @@ def test_dryrun(task, method):
         optimizer=CalibOptimizer(n_epochs=3)
     )
 
-    def train_and_sample(restore_path=None, start_current=False, save_dir=None, freeze=None, map_fit_config=None):
+    def train_and_sample(restore_path=None, start_current=False, save_dir=None, dump_state=False, save_n_steps=None, freeze=None, map_fit_config=None):
         prob_model.train(
             train_data_loader=train_data_loader,
             val_data_loader=val_data_loader,
             calib_data_loader=calib_data_loader,
-            fit_config=fit_config(restore_path, start_current, save_dir, freeze),
+            fit_config=fit_config(restore_path, start_current, save_dir, dump_state, save_n_steps, freeze),
             calib_config=calib_config,
             map_fit_config=map_fit_config
         )
@@ -111,13 +113,22 @@ def test_dryrun(task, method):
             posterior_approximator=METHODS[method]
         )
 
-    train_and_sample(map_fit_config=fit_config(restore_path=None, start_current=None, save_dir=None, freeze=None))
+    train_and_sample(
+        map_fit_config=fit_config(
+            restore_path=None,
+            start_current=None,
+            save_dir=None,
+            dump_state=False,
+            save_n_steps=None,
+            freeze=None
+        )
+    )
     train_and_sample(start_current=True)
     if method not in ["laplace", "swag"]:
         train_and_sample()
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        train_and_sample(map_fit_config=fit_config(restore_path=None, start_current=None, save_dir=None, freeze=None), save_dir=tmp_dir)
+        train_and_sample(map_fit_config=fit_config(restore_path=None, start_current=None, save_dir=None, dump_state=False, save_n_steps=None, freeze=None), save_dir=tmp_dir, save_n_steps=2, dump_state=True)
         train_and_sample(restore_path=tmp_dir)
         if method not in ["laplace", "swag"]:
             train_and_sample(freeze=freeze_fun)


### PR DESCRIPTION
When freezing part of the model and running SWAG only on the remainder, we can store only the stats corresponding to the unfrozen parameters in order to save memory.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently we save stats for all parameters, even if part of the parameters are frozen.

Issue Number: N/A

## What is the new behavior?

Only stats for unfrozen parameters are stored.
