### PR TITLE
enable self-hosted github runners when running tests

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,9 @@ jobs:
   build:
     # Functionality for testing documentation builds on multiple OSes and Python versions
     name: Build docs (${{ matrix.python-version }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on:
+      group: fortuna
+      labels: fortuna_ubuntu-latest_32-core
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on:
+      group: fortuna
+      labels: fortuna_ubuntu-latest_32-core
     strategy:
       matrix:
         # Select the Python versions to test against


### PR DESCRIPTION
We have some powerful self-hosted runners available. Let's try using them to run tests during checks.

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):