### PR TITLE
race condition in building docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -43,4 +43,4 @@ jobs:
           sudo apt install pandoc
           pip install pandoc
           cd docs
-          poetry run sphinx-build -b html -j auto source build/html
+          poetry run sphinx-build -b html source build/html


### PR DESCRIPTION
Fix occasionally failing "Build the documentation" workflow.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Building the docs with Sphinx can fail with `FileExistsError` exception if the following conditions are met:

- parallelized build is enabled with `-j auto` option
- there are >1 CPUs available (for example, with self-hosted Github runners)
- Sphinx randomly chooses to build >1 examples that use MNIST dataset (for example, `subnet_calibration` and `mnist_classification`)
- MNIST dataset hasn't been already downloaded and cached locally

Example: https://github.com/awslabs/fortuna/actions/runs/4960069129/jobs/8875033322?pr=46#step:4:615

Stacktrace:

```
Sphinx parallel build error:
nbsphinx.NotebookError: CellExecutionError in examples/mnist_classification.pct.py:
------------------

File ~/.cache/pypoetry/virtualenvs/aws-fortuna-b1cLBbij-py3.10/lib/python3.10/site-packages/etils/epath/backend.py:154, in _OsPathBackend.rename(self, path, dst)
    152 def rename(self, path: PathLike, dst: PathLike) -> None:
    153   if self.exists(dst):
--> 154     raise FileExistsError(
    155         f'Cannot rename {path}. Destination {dst} already exists.'
    156     )
    157   os.rename(path, dst)

FileExistsError: Cannot rename /home/runner/tensorflow_datasets/mnist/3.0.1.incompleteHD5YK7. Destination /home/runner/tensorflow_datasets/mnist/3.0.1 already exists.
```

## What is the new behavior?

Documentation examples are build sequentially.