### PR TITLE
optimize posterior state storage in SG-MCMC methods

### DIFF
--- a/fortuna/prob_model/posterior/sgmcmc/cyclical_sgld/cyclical_sgld_posterior.py
+++ b/fortuna/prob_model/posterior/sgmcmc/cyclical_sgld/cyclical_sgld_posterior.py
@@ -17,8 +17,8 @@ from fortuna.prob_model.posterior.map.map_trainer import (
 from fortuna.prob_model.posterior.run_preliminary_map import (
     run_preliminary_map,
 )
-from fortuna.prob_model.posterior.posterior_multi_state_repository import (
-    PosteriorMultiStateRepository,
+from fortuna.prob_model.posterior.sgmcmc.sgmcmc_posterior_state_repository import (
+    SGMCMCPosteriorStateRepository,
 )
 from fortuna.prob_model.posterior.sgmcmc.sgmcmc_posterior import (
     SGMCMCPosterior,
@@ -138,13 +138,28 @@ class CyclicalSGLDPosterior(SGMCMCPosterior):
         else:
             state = self._init_map_state(map_state, train_data_loader, fit_config)
 
+        if fit_config.optimizer.freeze_fun is not None:
+            which_params = get_trainable_paths(
+                params=state.params, freeze_fun=fit_config.optimizer.freeze_fun
+            )
+        else:
+            which_params = None
+
+        state = CyclicalSGLDState.convert_from_map_state(
+            map_state=state,
+            optimizer=fit_config.optimizer.method,
+            which_params=which_params,
+        )
+
         state = super()._freeze_optimizer_in_state(state, fit_config)
 
-        self.state = PosteriorMultiStateRepository(
+        self.state = SGMCMCPosteriorStateRepository(
             size=self.posterior_approximator.n_samples,
             checkpoint_dir=fit_config.checkpointer.save_checkpoint_dir
             if fit_config.checkpointer.dump_state is True
             else None,
+            which_params=which_params,
+            all_params=state.params if which_params else None,
         )
 
         cyclical_sampling_callback = CyclicalSGLDSamplingCallback(
@@ -159,13 +174,6 @@ class CyclicalSGLDPosterior(SGMCMCPosterior):
             keep_top_n_checkpoints=fit_config.checkpointer.keep_top_n_checkpoints,
             save_checkpoint_dir=fit_config.checkpointer.save_checkpoint_dir,
         )
-
-        state = CyclicalSGLDState.convert_from_map_state(
-            map_state=state,
-            optimizer=fit_config.optimizer.method,
-        )
-
-        state = super()._freeze_optimizer_in_state(state, fit_config)
 
         logging.info(f"Run CyclicalSGLD.")
         state, status = trainer.train(

--- a/fortuna/prob_model/posterior/sgmcmc/cyclical_sgld/cyclical_sgld_state.py
+++ b/fortuna/prob_model/posterior/sgmcmc/cyclical_sgld/cyclical_sgld_state.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
+from typing import (
+    Dict,
+    List,
+    Tuple,
+    Optional,
+)
+
 import jax.numpy as jnp
 
 from fortuna.prob_model.posterior.state import PosteriorState
-from fortuna.utils.strings import convert_string_to_jnp_array
+from fortuna.utils.strings import (
+    convert_string_to_jnp_array,
+    encode_tuple_of_lists_of_strings_to_numpy,
+)
 from fortuna.prob_model.posterior.map.map_state import MAPState
-from fortuna.typing import OptaxOptimizer
+from fortuna.typing import (
+    AnyKey,
+    Array,
+    OptaxOptimizer,
+)
 
 
 class CyclicalSGLDState(PosteriorState):
@@ -17,10 +31,14 @@ class CyclicalSGLDState(PosteriorState):
     """
 
     encoded_name: jnp.ndarray = convert_string_to_jnp_array("CyclicalSGLDState")
+    _encoded_which_params: Optional[Dict[str, List[Array]]] = None
 
     @classmethod
     def convert_from_map_state(
-        cls, map_state: MAPState, optimizer: OptaxOptimizer
+        cls,
+        map_state: MAPState,
+        optimizer: OptaxOptimizer,
+        which_params: Tuple[List[AnyKey], ...],
     ) -> CyclicalSGLDState:
         """
         Convert a MAP state into an CyclicalSGLDState state.
@@ -31,16 +49,22 @@ class CyclicalSGLDState(PosteriorState):
             A MAP posterior state.
         optimizer: OptaxOptimizer
             An Optax optimizer.
+        which_params: Tuple[List[AnyKey], ...]
+            Sequences of keys pointing to the stochastic parameters.
 
         Returns
         -------
-        SGHMCState
-            An SGHMC state.
+        CyclicalSGLDState
+            An Cyclical SGLD state.
         """
-        return CyclicalSGLDState.init(
+        _encoded_which_params = encode_tuple_of_lists_of_strings_to_numpy(
+            which_params
+        )
+        return cls.init(
             params=map_state.params,
             mutable=map_state.mutable,
             optimizer=optimizer,
             calib_params=map_state.calib_params,
             calib_mutable=map_state.calib_mutable,
+            _encoded_which_params=_encoded_which_params,
         )

--- a/fortuna/prob_model/posterior/sgmcmc/sghmc/sghmc_state.py
+++ b/fortuna/prob_model/posterior/sgmcmc/sghmc/sghmc_state.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
+from typing import (
+    Dict,
+    List,
+    Tuple,
+    Optional,
+)
+
 import jax.numpy as jnp
 
 from fortuna.prob_model.posterior.state import PosteriorState
-from fortuna.utils.strings import convert_string_to_jnp_array
+from fortuna.utils.strings import (
+    convert_string_to_jnp_array,
+    encode_tuple_of_lists_of_strings_to_numpy,
+)
 from fortuna.prob_model.posterior.map.map_state import MAPState
-from fortuna.typing import OptaxOptimizer
+from fortuna.typing import (
+    AnyKey,
+    Array,
+    OptaxOptimizer,
+)
 
 
 class SGHMCState(PosteriorState):
@@ -17,10 +31,14 @@ class SGHMCState(PosteriorState):
     """
 
     encoded_name: jnp.ndarray = convert_string_to_jnp_array("SGHMCState")
+    _encoded_which_params: Optional[Dict[str, List[Array]]] = None
 
     @classmethod
     def convert_from_map_state(
-        cls, map_state: MAPState, optimizer: OptaxOptimizer
+        cls,
+        map_state: MAPState,
+        optimizer: OptaxOptimizer,
+        which_params: Tuple[List[AnyKey], ...],
     ) -> SGHMCState:
         """
         Convert a MAP state into an SGHMC state.
@@ -31,16 +49,22 @@ class SGHMCState(PosteriorState):
             A MAP posterior state.
         optimizer: OptaxOptimizer
             An Optax optimizer.
+        which_params: Tuple[List[AnyKey], ...]
+            Sequences of keys pointing to the stochastic parameters.
 
         Returns
         -------
         SGHMCState
             An SGHMC state.
         """
-        return SGHMCState.init(
+        _encoded_which_params = encode_tuple_of_lists_of_strings_to_numpy(
+            which_params
+        )
+        return cls.init(
             params=map_state.params,
             mutable=map_state.mutable,
             optimizer=optimizer,
             calib_params=map_state.calib_params,
             calib_mutable=map_state.calib_mutable,
+            _encoded_which_params=_encoded_which_params,
         )

--- a/fortuna/prob_model/posterior/sgmcmc/sgmcmc_posterior_state_repository.py
+++ b/fortuna/prob_model/posterior/sgmcmc/sgmcmc_posterior_state_repository.py
@@ -1,0 +1,154 @@
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
+from flax.core import FrozenDict
+from fortuna.prob_model.posterior.posterior_multi_state_repository import (
+    PosteriorMultiStateRepository,
+)
+from fortuna.prob_model.posterior.state import PosteriorState
+from fortuna.typing import (
+    AnyKey,
+    OptaxOptimizer,
+    Path,
+    Params,
+)
+from fortuna.utils.nested_dicts import (
+    nested_get,
+    nested_set,
+)
+
+
+class SGMCMCPosteriorStateRepository(PosteriorMultiStateRepository):
+    def __init__(self,
+                 size: int,
+                 checkpoint_dir: Optional[Path] = None,
+                 all_params: Optional[Params] = None,
+                 which_params: Optional[Tuple[List[AnyKey], ...]] = None):
+        super().__init__(size=size, checkpoint_dir=checkpoint_dir)
+        self._all_params = all_params
+        self._which_params = which_params
+
+    def get(
+        self,
+        i: int = None,
+        checkpoint_path: Optional[Path] = None,
+        optimizer: Optional[OptaxOptimizer] = None,
+        prefix: str = "checkpoint_",
+        **kwargs,
+    ) -> Union[List[PosteriorState], PosteriorState]:
+        state = super().get(
+            i=i,
+            checkpoint_path=checkpoint_path,
+            optimizer=optimizer,
+            prefix=prefix,
+            **kwargs,
+        )
+        return self._update_state(state, modify="add")
+
+    def put(
+        self,
+        state: PosteriorState,
+        i: int = None,
+        checkpoint_path: Optional[Path] = None,
+        keep: int = 1,
+        prefix: str = "checkpoint_",
+    ) -> None:
+        state = self._update_state(state, modify="remove")
+        return super().put(
+            state=state,
+            i=i,
+            checkpoint_path=checkpoint_path,
+            keep=keep,
+            prefix=prefix,
+        )
+
+    def pull(
+        self,
+        i: int = None,
+        checkpoint_path: Path = None,
+        optimizer: Optional[OptaxOptimizer] = None,
+        prefix: str = "checkpoint_",
+        **kwargs,
+    ) -> PosteriorState:
+        state = super().pull(
+            i=i,
+            checkpoint_path=checkpoint_path,
+            optimizer=optimizer,
+            prefix=prefix,
+            **kwargs
+        )
+        return self._update_state(state, modify="add")
+
+    def extract(
+        self,
+        keys: List[str],
+        i: int = None,
+        checkpoint_path: Optional[Path] = None,
+        prefix: str = "checkpoint_",
+        **kwargs,
+    ) -> Union[Dict, List[Dict]]:
+        def _extract(_i):
+            state = self.get(
+                i=_i,
+                checkpoint_path=checkpoint_path,
+                prefix=prefix,
+            )
+            return {k: getattr(state, k) for k in keys}
+
+        if i is not None:
+            return _extract(i)
+        dicts = []
+        for i in range(self.size):
+            dicts.append(_extract(i))
+        return dicts
+
+    def _update_state(
+        self,
+        state: Union[List[PosteriorState], PosteriorState],
+        modify: str = "add",
+    ) -> Union[List[PosteriorState], PosteriorState]:
+        if self._which_params is None:
+            return state
+
+        if isinstance(state, list):
+            return [_update_state(_state, modify=modify) for _state in state]
+
+        if modify == "add":
+            state = state.replace(
+                params=FrozenDict(
+                    nested_set(
+                        d=self._all_params.unfreeze(),
+                        key_paths=self._which_params,
+                        objs=tuple(
+                            [
+                                nested_get(d=state.params, keys=path)
+                                for path in self._which_params
+                            ]
+                        ),
+                    )
+                )
+            )
+        elif modify == "remove":
+            state = state.replace(
+                params=FrozenDict(
+                    nested_set(
+                        d={},
+                        key_paths=self._which_params,
+                        objs=tuple(
+                            [
+                                nested_get(d=state.params, keys=path)
+                                for path in self._which_params
+                            ]
+                        ),
+                        allow_nonexistent=True,
+                    )
+                ),
+                step=state.step,
+            )
+
+        return state

--- a/fortuna/prob_model/posterior/sgmcmc/sgmcmc_preconditioner.py
+++ b/fortuna/prob_model/posterior/sgmcmc/sgmcmc_preconditioner.py
@@ -2,8 +2,8 @@ import jax
 import jax.numpy as jnp
 
 from optax._src.base import PyTree
-from optax import Params
 from typing import NamedTuple, Callable
+from fortuna.typing import Params
 
 
 PreconditionerState = NamedTuple

--- a/fortuna/prob_model/posterior/sgmcmc/sgmcmc_sampling_callback.py
+++ b/fortuna/prob_model/posterior/sgmcmc/sgmcmc_sampling_callback.py
@@ -45,17 +45,17 @@ class SGMCMCSamplingCallback(Callback):
         self._current_step += 1
 
         if self._do_sample(self._current_step, self._samples_count):
-            if self._save_checkpoint_dir:
-                self._trainer.save_checkpoint(
-                    state,
-                    pathlib.Path(self._save_checkpoint_dir) / str(self._samples_count),
-                    force_save=True,
-                )
             self._state_repository.put(
                 state=state,
                 i=self._samples_count,
                 keep=self._keep_top_n_checkpoints,
             )
+            if self._save_checkpoint_dir:
+                self._trainer.save_checkpoint(
+                    self._state_repository.state[self._samples_count].get(),
+                    pathlib.Path(self._save_checkpoint_dir) / str(self._samples_count),
+                    force_save=True,
+                )
             self._samples_count += 1
 
         return state

--- a/fortuna/utils/nested_dicts.py
+++ b/fortuna/utils/nested_dicts.py
@@ -35,7 +35,10 @@ def nested_get(
 
 
 def nested_set(
-    d: Dict[AnyKey, Any], key_paths: Tuple[List[AnyKey], ...], objs: Tuple[Any]
+    d: Dict[AnyKey, Any],
+    key_paths: Tuple[List[AnyKey], ...],
+    objs: Tuple[Any],
+    allow_nonexistent: bool = False,
 ) -> Dict[AnyKey, Any]:
     """
     Set the values of a nested dictionary for the specified sequences of keys.
@@ -49,6 +52,8 @@ def nested_set(
     :param objs: Tuple
         Each element of the tuple is an object that will be assigned to the item specified by the corresponding
         sequence of keys.
+    :param allow_nonexisten: bool
+        Whether to create sequence of keys that are not found in the input dictionary or throw an exception.
     """
     if type(key_paths) != tuple:
         raise TypeError("`key_paths` must be a tuple.")
@@ -65,9 +70,12 @@ def nested_set(
         for key in keys[:-1]:
             if key in d2:
                 d2 = d2[key]
+            elif allow_nonexistent:
+                d2[key] = {}
+                d2 = d2[key]
             else:
                 raise KeyError(error_msg)
-        if keys[-1] in d2:
+        if keys[-1] in d2 or allow_nonexistent:
             d2[keys[-1]] = o
         else:
             raise KeyError(error_msg)


### PR DESCRIPTION
Refactor storage & checkpointing behavior in the posterior state repository for SG-MCMC methods.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

SG-MCMC posterior state currently stores all the model parameters for each sample, even if `freeze_fun` is given. Instead, it should keep only a subset of unfrozen parameters.

## What is the new behavior?

Keep only the weights for unfrozen parameters and merge them with the frozen part when needed.
