### PR TITLE
Add model editor to prob and calib models

### DIFF
--- a/docs/source/references/prob_model/model_editor.rst
+++ b/docs/source/references/prob_model/model_editor.rst
@@ -1,0 +1,6 @@
+Model editor
+===================
+A model editor is an object that takes the forward pass as a function of model parameters and a batch of input data
+points, and can modify its outputs in a custom way.
+
+.. automodule:: fortuna.model_editor.base

--- a/docs/source/references/prob_model/prob_model.rst
+++ b/docs/source/references/prob_model/prob_model.rst
@@ -28,6 +28,7 @@ Please find their references below.
    posterior/posterior
    joint
    prior
+   model_editor
    fit_config
    prob_calib_config
    callbacks

--- a/fortuna/calib_model/regression.py
+++ b/fortuna/calib_model/regression.py
@@ -13,6 +13,7 @@ from fortuna.data import DataLoader
 from fortuna.likelihood.regression import RegressionLikelihood
 from fortuna.loss.regression.scaled_mse import scaled_mse_fn
 from fortuna.model.model_manager.regression import RegressionModelManager
+from fortuna.model_editor.base import ModelEditor
 from fortuna.prob_output_layer.regression import RegressionProbOutputLayer
 from fortuna.typing import (
     Outputs,
@@ -23,7 +24,11 @@ from fortuna.typing import (
 
 class CalibRegressor(CalibModel):
     def __init__(
-        self, model: nn.Module, likelihood_log_variance_model: nn.Module, seed: int = 0
+        self,
+        model: nn.Module,
+        likelihood_log_variance_model: nn.Module,
+        model_editor: Optional[ModelEditor] = None,
+        seed: int = 0,
     ):
         r"""
         A calibration regressor class.
@@ -39,6 +44,8 @@ class CalibRegressor(CalibModel):
             A model characterizing the log-variance of a Gaussian likelihood function. The outputs must belong to the
             same space as the target variables. Let :math:`x` be input variables and :math:`w` the random model
             parameters. Then the model is described by a function :math:`\log\sigma^2(w, x)`.
+        model_editor : ModelEditor
+            A model_editor objects. It takes the forward pass and transforms the outputs.
         seed: int
             A random seed.
 
@@ -61,7 +68,7 @@ class CalibRegressor(CalibModel):
             This denotes the predictive distribution, that is :math:`p(y|\phi, x, \mathcal{D})`.
         """
         self.model_manager = RegressionModelManager(
-            model, likelihood_log_variance_model
+            model, likelihood_log_variance_model, model_editor=model_editor
         )
         self.prob_output_layer = RegressionProbOutputLayer()
         self.likelihood = RegressionLikelihood(

--- a/fortuna/loss/classification/cross_entropy.py
+++ b/fortuna/loss/classification/cross_entropy.py
@@ -5,46 +5,30 @@ from typing import (
 )
 
 import jax
-from jax import value_and_grad
 import jax.numpy as jnp
 import jax.scipy as jsp
 
-from fortuna.typing import (
-    Array,
-    Batch,
-    Params,
-)
+from fortuna.typing import Array
 
 
 def cross_entropy_loss_fn(
-    apply: Callable[[Params, Array], jnp.ndarray],
-    params: Params,
-    batch: Batch,
-) -> Tuple[jnp.ndarray, Any]:
+    outputs: jnp.ndarray,
+    targets: Array,
+) -> jnp.ndarray:
     """
     A cross-entropy loss function. Check `here <https://en.wikipedia.org/wiki/Cross_entropy>`_ for reference.
 
     Parameters
     ----------
-    apply: Callable[[Params, Batch], jnp.ndarray]
-        A function evaluating the model.
-    params: Params
-        Model parameters.
-    batch: Batch
-        Batch of data points.
+    outputs: Array
+        Model outputs to be passed to the loss.
+    targets: Array
+        Target data points.
 
     Returns
     -------
     Tuple[jnp.ndarray, Any]
         The cross-entropy loss evaluation and auxiliary objects.
     """
-    outputs, aux = apply(params, batch[0])
-    return cross_entropy_loss_fn_from_outputs_and_targets(outputs, batch[1]), aux
-
-
-def cross_entropy_loss_fn_from_outputs_and_targets(
-    outputs: jnp.ndarray,
-    targets: Array,
-) -> jnp.ndarray:
     targets = jax.nn.one_hot(targets, outputs.shape[-1])
     return jnp.mean(jsp.special.logsumexp(outputs, -1) - jnp.sum(targets * outputs, -1))

--- a/fortuna/loss/classification/focal_loss.py
+++ b/fortuna/loss/classification/focal_loss.py
@@ -1,53 +1,13 @@
-from typing import (
-    Any,
-    Callable,
-    Tuple,
-)
-
 from jax.nn import (
     one_hot,
     softmax,
 )
 import jax.numpy as jnp
 
-from fortuna.typing import (
-    Array,
-    Batch,
-    Params,
-)
+from fortuna.typing import Array
 
 
 def focal_loss_fn(
-    apply: Callable[[Params, Array], jnp.ndarray],
-    params: Params,
-    batch: Batch,
-    gamma: float = 2.0,
-) -> Tuple[jnp.ndarray, Any]:
-    """
-    A focal loss function. See `[Mukhoti J. et a., 2020] <https://proceedings.neurips.cc/paper/2020/file/aeb7b30ef1d024a76f21a1d40e30c302-Paper.pdf>`_
-    for reference.
-
-    Parameters
-    ----------
-    apply: Callable[[Params, Batch], jnp.ndarray]
-        A function evaluating the model.
-    params: Params
-        Model parameters.
-    batch: Batch
-        Batch of data points.
-    gamma: float
-        Hyper-parameter of the focal loss.
-
-    Returns
-    -------
-    Tuple[jnp.ndarray, Any]
-        The focal loss evaluation and auxiliary objects.
-    """
-    outputs, aux = apply(params, batch[0])
-    return focal_loss_fn_from_outputs_and_targets(outputs, batch[1], gamma), aux
-
-
-def focal_loss_fn_from_outputs_and_targets(
     outputs: Array,
     targets: Array,
     gamma: float = 2.0,

--- a/fortuna/loss/regression/scaled_mse.py
+++ b/fortuna/loss/regression/scaled_mse.py
@@ -1,47 +1,28 @@
-from typing import (
-    Any,
-    Callable,
-    Tuple,
-)
+from typing import Tuple
 
 import jax.numpy as jnp
 
-from fortuna.typing import (
-    Array,
-    Batch,
-    Params,
-)
+from fortuna.typing import Array
 
 
 def scaled_mse_fn(
-    apply: Callable[[Params, Array], jnp.ndarray],
-    params: Params,
-    batch: Batch,
-) -> Tuple[jnp.ndarray, Any]:
+    outputs: Array,
+    targets: Array,
+) -> jnp.ndarray:
     """
     Compute a variance-scaled mean-squared-error (MSE).
 
     Parameters
     ----------
-    apply: Callable[[Params, Batch], jnp.ndarray]
-        A function evaluating the model.
-    params: Params
-        Model parameters.
-    batch: Batch
-        Batch of data points.
+    outputs: Array
+        Model outputs to be passed to the loss.
+    targets: Array
+        Target data points.
 
     Returns
     -------
     Tuple[jnp.ndarray, Any]
         Scaled MSE evalution and auxiliary objects.
     """
-    outputs, aux = apply(params, batch[0])
-    return scaled_mse_fn_from_outputs_and_targets(outputs, batch[1]), aux
-
-
-def scaled_mse_fn_from_outputs_and_targets(
-    outputs: Array,
-    targets: Array,
-) -> jnp.ndarray:
     means, log_vars = jnp.split(outputs, 2, axis=-1)
     return jnp.mean(jnp.sum(jnp.exp(-log_vars) * (targets - means) ** 2 + log_vars, -1))

--- a/fortuna/model/model_manager/base.py
+++ b/fortuna/model/model_manager/base.py
@@ -27,8 +27,9 @@ class ModelManager(WithRNG, abc.ABC):
     It orchestrates the forward pass of the models in the probabilistic model.
     """
 
-    def __init__(self, model: nn.Module):
+    def __init__(self, model: nn.Module, model_editor: Optional[nn.Module] = None):
         self.model = model
+        self.model_editor = model_editor
 
     @abc.abstractmethod
     def apply(

--- a/fortuna/model/model_manager/regression.py
+++ b/fortuna/model/model_manager/regression.py
@@ -8,6 +8,7 @@ from typing import (
 from flax.core import FrozenDict
 import flax.linen as nn
 from flax.training.checkpoints import PyTree
+import jax
 from jax import random
 from jax._src.prng import PRNGKeyArray
 import jax.numpy as jnp
@@ -18,10 +19,16 @@ from fortuna.typing import (
     Mutable,
     Params,
 )
+from fortuna.utils.data import get_inputs_from_shape
 
 
 class RegressionModelManager(ModelManager):
-    def __init__(self, model: nn.Module, likelihood_log_variance_model: nn.Module):
+    def __init__(
+        self,
+        model: nn.Module,
+        likelihood_log_variance_model: nn.Module,
+        model_editor: Optional[nn.Module] = None,
+    ):
         r"""
         Regression model manager class. It orchestrates the forward pass of the model in the probabilistic model.
 
@@ -37,7 +44,7 @@ class RegressionModelManager(ModelManager):
             same space as the target variables. Let :math:`x` be input variables and :math:`w` the random model
             parameters. Then the model is described by a function :math:`\log\sigma^2(w, x)`.
         """
-        super(RegressionModelManager, self).__init__(model)
+        super(RegressionModelManager, self).__init__(model, model_editor)
         self.likelihood_log_variance_model = likelihood_log_variance_model
 
     def apply(
@@ -48,10 +55,7 @@ class RegressionModelManager(ModelManager):
         train: bool = False,
         rng: Optional[PRNGKeyArray] = None,
     ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, PyTree]]:
-        if mutable is None:
-            mutable = False
-        model_variables = params["model"].unfreeze()
-        lik_log_var_variables = params["lik_log_var"].unfreeze()
+        params = params.unfreeze()
 
         # setup dropout key
         if rng is not None:
@@ -62,65 +66,80 @@ class RegressionModelManager(ModelManager):
             model_rngs = None
             lik_log_var_rngs = None
 
-        if mutable:
-            try:
-                model_mutable_variables = mutable["model"].unfreeze()
-                model_variables.update(model_mutable_variables)
-                model_mutable = list(model_mutable_variables.keys())
-            except KeyError:
-                model_mutable = False
-            try:
-                lik_log_var_mutable_variables = mutable["lik_log_var"].unfreeze()
-                lik_log_var_variables.update(lik_log_var_mutable_variables)
-                lik_log_var_mutable = list(lik_log_var_mutable_variables.keys())
-            except KeyError:
-                lik_log_var_mutable = False
-        else:
-            model_mutable = False
-            lik_log_var_mutable = False
+        if mutable is not None:
+            mutable["model"] = mutable.get("model")
+            mutable["lik_log_var"] = mutable.get("lik_log_var")
 
-        aux = {}
-        if train and model_mutable:
-            model_outputs, model_mutable = self.model.apply(
-                model_variables,
-                inputs,
+        model_has_aux = train and mutable is not None and mutable["model"] is not None
+        lik_log_var_has_aux = (
+            train and mutable is not None and mutable["lik_log_var"] is not None
+        )
+
+        def apply_fn(p, x, m_mutable, llv_mutable):
+            model_outputs = self.model.apply(
+                p["model"],
+                x,
                 train=train,
-                mutable=model_mutable,
+                mutable=m_mutable,
                 rngs=model_rngs,
             )
-            aux.update({"model": model_mutable})
-        else:
-            model_outputs = self.model.apply(
-                model_variables, inputs, train=train, mutable=False, rngs=model_rngs
-            )
-        if train and lik_log_var_mutable:
-            (
-                lik_log_var_outputs,
-                lik_log_var_mutable,
-            ) = self.likelihood_log_variance_model.apply(
-                lik_log_var_variables,
-                train=train,
-                mutable=lik_log_var_mutable,
-                rngs=lik_log_var_rngs,
-            )
-            aux.update({"likelihood_log_variance_model": lik_log_var_mutable})
-        else:
             lik_log_var_outputs = self.likelihood_log_variance_model.apply(
-                lik_log_var_variables,
-                inputs,
+                p["lik_log_var"],
+                x,
                 train=train,
-                mutable=False,
+                mutable=llv_mutable,
                 rngs=lik_log_var_rngs,
             )
 
-        outputs = jnp.concatenate((model_outputs, lik_log_var_outputs), axis=-1)
-        if model_outputs.shape[-1] != lik_log_var_outputs.shape[-1]:
-            raise ValueError(
-                f"""The output dimensions of `model` and `likelihood_log_variance_model must be the same.
-            However, {model_outputs.shape[-1]} and {lik_log_var_outputs.shape[-1]} were found, respectively."""
+            if isinstance(model_outputs, tuple) and not model_has_aux:
+                model_outputs = model_outputs[0]
+            if isinstance(lik_log_var_outputs, tuple) and not lik_log_var_has_aux:
+                lik_log_var_outputs = lik_log_var_outputs[0]
+
+            if model_has_aux:
+                model_outputs, m_mutable = model_outputs
+            if lik_log_var_has_aux:
+                lik_log_var_outputs, llv_mutable = lik_log_var_outputs
+
+            self._check_outputs(model_outputs, lik_log_var_outputs)
+
+            aux = dict()
+            if m_mutable or llv_mutable:
+                aux["mutable"] = dict()
+                if m_mutable:
+                    aux["mutable"]["model"] = m_mutable
+                if llv_mutable:
+                    aux["mutable"]["lik_log_var"] = m_mutable
+
+            return jnp.concatenate(
+                (model_outputs, lik_log_var_outputs), axis=-1
+            ), FrozenDict(aux)
+
+        if self.model_editor is not None:
+            outputs, aux = self.model_editor.apply(
+                params["model_editor"],
+                apply_fn=lambda p, x: apply_fn(
+                    p,
+                    x,
+                    m_mutable=mutable["model"] if mutable is not None else False,
+                    llv_mutable=mutable["lik_log_var"]
+                    if mutable is not None
+                    else False,
+                ),
+                model_params=params,
+                x=inputs,
+                has_aux=True,
             )
+        else:
+            outputs, aux = apply_fn(
+                params,
+                inputs,
+                m_mutable=mutable["model"] if mutable is not None else False,
+                llv_mutable=mutable["lik_log_var"] if mutable is not None else False,
+            )
+
         if len(aux) > 0:
-            return outputs, {"mutable": FrozenDict(aux)}
+            return outputs, aux
         return outputs
 
     def init(
@@ -140,9 +159,52 @@ class RegressionModelManager(ModelManager):
             "params": lik_log_var_params_key,
             "dropout": lik_log_var_params_key,
         }
-        return dict(
+        params = dict(
             model=self.model.init(model_rngs, jnp.zeros((1,) + input_shape), **kwargs),
             lik_log_var=self.likelihood_log_variance_model.init(
                 lik_log_var_rngs, jnp.zeros((1,) + input_shape), **kwargs
             ),
         )
+
+        def apply_fn(p, x):
+            model_outputs = self.model.apply(
+                p["model"],
+                x,
+                rngs=model_rngs,
+            )
+            lik_log_var_outputs = self.likelihood_log_variance_model.apply(
+                p["lik_log_var"],
+                x,
+                rngs=lik_log_var_rngs,
+            )
+
+            self._check_outputs(model_outputs, lik_log_var_outputs)
+
+            return jnp.concatenate((model_outputs, lik_log_var_outputs), axis=-1)
+
+        if self.model_editor is not None:
+            if rng is None:
+                rng = self.rng
+            rng, params_key, dropout_key = random.split(rng, 3)
+            rngs = {"params": params_key, "dropout": dropout_key}
+            params.update(
+                dict(
+                    model_editor=self.model_editor.init(
+                        rngs,
+                        apply_fn=apply_fn,
+                        model_params=params,
+                        x=get_inputs_from_shape(input_shape),
+                        has_aux=False,
+                    )
+                )
+            )
+        return params
+
+    def _check_outputs(
+        self, model_outputs: jnp.ndarray, lik_log_var_outputs: jnp.ndarray
+    ) -> None:
+        if model_outputs.shape[-1] != lik_log_var_outputs.shape[-1]:
+            raise ValueError(
+                f"""The output dimensions of `model` and `likelihood_log_variance_model must be the same.
+            However, {model_outputs.shape[-1]} and {lik_log_var_outputs.shape[-1]} were found, respectively."""
+            )

--- a/fortuna/model/model_manager/state.py
+++ b/fortuna/model/model_manager/state.py
@@ -20,7 +20,7 @@ class ModelManagerState:
 
     def __init__(self, params: Params, mutable: Optional[Mutable] = None):
         """
-        An model manager state class.
+        A model manager state class.
 
         Parameters
         ----------

--- a/fortuna/model/model_manager/transformers/classification.py
+++ b/fortuna/model/model_manager/transformers/classification.py
@@ -20,6 +20,7 @@ from fortuna.model.model_manager.classification import (
     ClassificationModelManager,
     SNGPClassificationModelManagerMixin,
 )
+from fortuna.model_editor.base import ModelEditor
 from fortuna.typing import (
     Array,
     Mutable,
@@ -48,21 +49,40 @@ class HuggingFaceClassificationModelManager(ClassificationModelManager):
         model_kwargs = {}
         if mutable is not None:
             model_kwargs = {"mutable": mutable}
-        outputs = self.model(
-            **inputs,
-            params=params["model"]["params"],
-            dropout_rng=dropout_rng,
-            train=train,
-            output_attentions=kwargs.get("output_attentions"),
-            output_hidden_states=kwargs.get("output_hidden_states"),
-            return_dict=kwargs.get("return_dict"),
-            **model_kwargs,
-        )
-        if train and mutable:
+
+        has_aux = train and mutable
+
+        def apply_fn(p, x):
+            _outputs = self.model(
+                **x,
+                params=p,
+                dropout_rng=dropout_rng,
+                train=train,
+                output_attentions=kwargs.get("output_attentions"),
+                output_hidden_states=kwargs.get("output_hidden_states"),
+                return_dict=kwargs.get("return_dict"),
+                **model_kwargs,
+            )
+            if hasattr(_outputs, "logits"):
+                _outputs = _outputs.logits
+
+            if isinstance(_outputs, tuple) and not has_aux:
+                _outputs = _outputs[0]
+            return _outputs
+
+        if self.model_editor is not None:
+            outputs = self.model_editor.apply(
+                params["model_editor"],
+                apply_fn=apply_fn,
+                model_params=params["model"]["params"],
+                x=inputs,
+                has_aux=has_aux,
+            )
+        else:
+            outputs = apply_fn(params["model"]["params"], inputs)
+
+        if has_aux:
             outputs, mutable = outputs
-        if hasattr(outputs, "logits"):
-            outputs = outputs.logits
-        if train and mutable:
             return outputs, {"mutable": FrozenDict({"model": mutable})}
         return outputs
 
@@ -73,15 +93,48 @@ class HuggingFaceClassificationModelManager(ClassificationModelManager):
             "At the moment Fortuna supports models from Hugging Face that are loaded via "
             "`from_pretrained` method, which also takes care of model initialization."
         )
-        return {"model": {"params": self.model.params}}
+        params = {"model": {"params": self.model.params}}
+        if self.model_editor is not None:
+            if rng is None:
+                rng = self.rng
+            output_shape = jax.eval_shape(
+                self.model, **get_inputs_from_shape(input_shape)
+            ).logits.shape
+            rng, params_key, dropout_key = random.split(rng, 3)
+            rngs = {"params": params_key, "dropout": dropout_key}
+
+            def apply_fn(p, x):
+                _outputs = self.model(x, params=p)
+                if hasattr(_outputs, "logits"):
+                    _outputs = _outputs.logits
+                return _outputs
+
+            params.update(
+                dict(
+                    model_editor=self.model_editor.init(
+                        rngs,
+                        apply_fn=apply_fn,
+                        model_params=params["model"]["params"],
+                        x=jnp.zeros(output_shape),
+                        has_aux=False,
+                    )
+                )
+            )
+        return params
 
 
 class SNGPHuggingFaceClassificationModelManager(
     SNGPClassificationModelManagerMixin, HuggingFaceClassificationModelManager
 ):
-    def __init__(self, model: nn.Module, *args, **kwargs):
+    def __init__(
+        self,
+        model: nn.Module,
+        model_editor: Optional[ModelEditor] = None,
+        *args,
+        **kwargs,
+    ):
         super(SNGPHuggingFaceClassificationModelManager, self).__init__(
-            model, *args, **kwargs
+            model, model_editor=model_editor, *args, **kwargs
         )
 
     def init(
@@ -105,5 +158,31 @@ class SNGPHuggingFaceClassificationModelManager(
         rng, params_key, dropout_key = random.split(rng, 3)
         rngs = {"params": params_key, "dropout": dropout_key}
         gp_params = self._gp_output_model.init(rngs, jnp.zeros(output_shape), **kwargs)
-        params = nested_update(self.model.params, gp_params.unfreeze())
-        return dict(model=FrozenDict(params))
+        params = dict(model=nested_update(self.model.params, gp_params.unfreeze()))
+
+        if self.model_editor is not None:
+            rng, params_key, dropout_key = random.split(rng, 3)
+            rngs = {"params": params_key, "dropout": dropout_key}
+
+            mutable = dict(
+                model=FrozenDict(
+                    {k: v for k, v in params["model"].items() if k != "params"}
+                )
+            )
+
+            def apply_fn(p, x):
+                _outputs = self.model(**x, params=p, mutable=mutable)
+                return _outputs
+
+            params.update(
+                dict(
+                    model_editor=self.model_editor.init(
+                        rngs,
+                        apply_fn=apply_fn,
+                        model_params=params["model"]["params"],
+                        x=get_inputs_from_shape(input_shape),
+                        has_aux=False,
+                    )
+                )
+            )
+        return params

--- a/fortuna/model_editor/base.py
+++ b/fortuna/model_editor/base.py
@@ -1,0 +1,48 @@
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Tuple,
+    Union,
+)
+
+import flax.linen as nn
+import jax.numpy as jnp
+
+from fortuna.typing import (
+    InputData,
+    Params,
+)
+
+
+class ModelEditor(nn.Module):
+    @nn.compact
+    def __call__(
+        self,
+        apply_fn: Callable[
+            [Params, InputData], Union[jnp.ndarray, Tuple[jnp.ndarray, Dict]]
+        ],
+        model_params: Params,
+        x: Any,
+        has_aux: bool,
+    ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, Dict]]:
+        """
+        Apply a transformation to the forward pass.
+
+        Parameters
+        ----------
+        apply_fn: Callable[[Params, InputData], Union[jnp.ndarray, Tuple[jnp.ndarray, Dict]]]
+            The model forward pass.
+        model_params: Params
+            The model parameters.
+        x: Array
+            Batch of inputs.
+        has_aux: bool
+            Whether the forward pass returns auxiliary objects.
+
+        Returns
+        -------
+        Union[jnp.ndarray, Tuple[jnp.ndarray, Dict]]
+            Return the transformed outputs, and auxiliary objects if available.
+        """
+        pass

--- a/fortuna/model_editor/classification.py
+++ b/fortuna/model_editor/classification.py
@@ -1,0 +1,34 @@
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Tuple,
+    Union,
+)
+
+import flax.linen as nn
+import jax.numpy as jnp
+
+from fortuna.model_editor.base import ModelEditor
+from fortuna.typing import (
+    InputData,
+    Params,
+)
+from fortuna.utils.probit import probit_scaling
+
+
+class ProbitClassificationModelEditor(ModelEditor):
+    @nn.compact
+    def __call__(
+        self,
+        apply_fn: Callable[
+            [Params, InputData], Union[jnp.ndarray, Tuple[jnp.ndarray, Dict]]
+        ],
+        model_params: Params,
+        x: Any,
+        has_aux: bool,
+    ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, Dict]]:
+        log_var = self.param("log_var", nn.initializers.zeros, (1,))
+        return probit_scaling(
+            apply_fn, model_params, x, log_var=log_var, has_aux=has_aux
+        )

--- a/fortuna/output_calib_model/classification.py
+++ b/fortuna/output_calib_model/classification.py
@@ -7,9 +7,7 @@ import flax.linen as nn
 import jax.numpy as jnp
 import numpy as np
 
-from fortuna.loss.classification.focal_loss import (
-    focal_loss_fn_from_outputs_and_targets,
-)
+from fortuna.loss.classification.focal_loss import focal_loss_fn
 from fortuna.output_calib_model.base import OutputCalibModel
 from fortuna.output_calib_model.config.base import Config
 from fortuna.output_calib_model.predictive.classification import (
@@ -74,9 +72,7 @@ class OutputCalibClassifier(OutputCalibModel):
         calib_targets: Array,
         val_outputs: Optional[Array] = None,
         val_targets: Optional[Array] = None,
-        loss_fn: Callable[
-            [Outputs, Targets], jnp.ndarray
-        ] = focal_loss_fn_from_outputs_and_targets,
+        loss_fn: Callable[[Outputs, Targets], jnp.ndarray] = focal_loss_fn,
         config: Config = Config(),
     ) -> Status:
         """

--- a/fortuna/output_calib_model/regression.py
+++ b/fortuna/output_calib_model/regression.py
@@ -6,7 +6,7 @@ from typing import (
 import flax.linen as nn
 import jax.numpy as jnp
 
-from fortuna.loss.regression.scaled_mse import scaled_mse_fn_from_outputs_and_targets
+from fortuna.loss.regression.scaled_mse import scaled_mse_fn
 from fortuna.output_calib_model.base import OutputCalibModel
 from fortuna.output_calib_model.config.base import Config
 from fortuna.output_calib_model.predictive.regression import RegressionPredictive
@@ -69,9 +69,7 @@ class OutputCalibRegressor(OutputCalibModel):
         calib_targets: Array,
         val_outputs: Optional[Array] = None,
         val_targets: Optional[Array] = None,
-        loss_fn: Callable[
-            [Outputs, Targets], jnp.ndarray
-        ] = scaled_mse_fn_from_outputs_and_targets,
+        loss_fn: Callable[[Outputs, Targets], jnp.ndarray] = scaled_mse_fn,
         config: Config = Config(),
     ) -> Status:
         """

--- a/fortuna/prob_model/classification.py
+++ b/fortuna/prob_model/classification.py
@@ -17,6 +17,7 @@ from fortuna.model.model_manager.classification import (
 from fortuna.model.model_manager.name_to_model_manager import (
     ClassificationModelManagers,
 )
+from fortuna.model_editor.base import ModelEditor
 from fortuna.output_calibrator.classification import ClassificationTemperatureScaler
 from fortuna.output_calibrator.output_calib_manager.base import OutputCalibManager
 from fortuna.prob_model.base import ProbModel
@@ -51,6 +52,7 @@ class ProbClassifier(ProbModel):
         prior: Prior = IsotropicGaussianPrior(),
         posterior_approximator: PosteriorApproximator = SWAGPosteriorApproximator(),
         output_calibrator: Optional[nn.Module] = ClassificationTemperatureScaler(),
+        model_editor: Optional[ModelEditor] = None,
         seed: int = 0,
     ):
         r"""
@@ -73,6 +75,8 @@ class ProbClassifier(ProbModel):
             logits with a scalar temperature parameter. Given outputs :math:`o` of the model manager, the output
             calibrator is described by a function :math:`g(\phi, o)`, where `phi` are deterministic
             calibration parameters.
+        model_editor : ModelEditor
+            A model_editor objects. It takes the forward pass and transforms the outputs.
         seed: int
             A random seed.
 
@@ -119,7 +123,7 @@ class ProbClassifier(ProbModel):
             ClassificationModelManagers, posterior_approximator.__str__()
         ).value
         self.model_manager = self._get_model_manager(
-            model, model_manager_cls, posterior_approximator
+            model, model_editor, model_manager_cls, posterior_approximator
         )
 
         self.likelihood = ClassificationLikelihood(
@@ -157,6 +161,7 @@ class ProbClassifier(ProbModel):
     def _get_model_manager(
         self,
         model: nn.Module,
+        model_editor: ModelEditor,
         model_manager_cls: Type,
         posterior_approximator: PosteriorApproximator,
     ) -> ClassificationModelManager:
@@ -182,13 +187,19 @@ class ProbClassifier(ProbModel):
                 and model_manager_cls == SNGPClassificationModelManager
             ):
                 model_manager = SNGPHuggingFaceClassificationModelManager(
-                    model=model, **posterior_approximator.posterior_method_kwargs
+                    model=model,
+                    model_editor=model_editor,
+                    **posterior_approximator.posterior_method_kwargs,
                 )
             elif isinstance(model, FlaxPreTrainedModel):
-                model_manager = HuggingFaceClassificationModelManager(model)
+                model_manager = HuggingFaceClassificationModelManager(
+                    model, model_editor=model_editor
+                )
             else:
                 model_manager = model_manager_cls(
-                    model=model, **posterior_approximator.posterior_method_kwargs
+                    model=model,
+                    model_editor=model_editor,
+                    **posterior_approximator.posterior_method_kwargs,
                 )
         except ModuleNotFoundError as e:
             logging.warning(
@@ -198,7 +209,9 @@ class ProbClassifier(ProbModel):
                 'Using poetry, you can achieve this by entering: `poetry install --extras "transformers"`'
             )
             model_manager = model_manager_cls(
-                model=model, **posterior_approximator.posterior_method_kwargs
+                model=model,
+                model_editor=model_editor,
+                **posterior_approximator.posterior_method_kwargs,
             )
         return model_manager
 

--- a/fortuna/prob_model/posterior/laplace/laplace_posterior.py
+++ b/fortuna/prob_model/posterior/laplace/laplace_posterior.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import pathlib
 from typing import (
     Dict,
     List,

--- a/fortuna/prob_model/regression.py
+++ b/fortuna/prob_model/regression.py
@@ -9,6 +9,7 @@ import numpy as np
 from fortuna.data.loader import DataLoader
 from fortuna.likelihood.regression import RegressionLikelihood
 from fortuna.model.model_manager.regression import RegressionModelManager
+from fortuna.model_editor.base import ModelEditor
 from fortuna.output_calibrator.output_calib_manager.base import OutputCalibManager
 from fortuna.output_calibrator.regression import RegressionTemperatureScaler
 from fortuna.prob_model.base import ProbModel
@@ -37,6 +38,7 @@ class ProbRegressor(ProbModel):
         prior: Prior = IsotropicGaussianPrior(),
         posterior_approximator: PosteriorApproximator = SWAGPosteriorApproximator(),
         output_calibrator: Optional[nn.Module] = RegressionTemperatureScaler(),
+        model_editor: Optional[ModelEditor] = None,
         seed: int = 0,
     ):
         r"""
@@ -63,6 +65,8 @@ class ProbRegressor(ProbModel):
             of the likelihood with a scalar temperature parameter. Given outputs :math:`o` of the model manager, the
             output calibrator is described by a function :math:`g(\phi, o)`, where `phi` are deterministic
             calibration parameters.
+        model_editor : ModelEditor
+            A model_editor objects. It takes the forward pass and transforms the outputs.
         seed: int
             A random seed.
 
@@ -104,7 +108,7 @@ class ProbRegressor(ProbModel):
         self.output_calibrator = output_calibrator
 
         self.model_manager = RegressionModelManager(
-            model, likelihood_log_variance_model
+            model, likelihood_log_variance_model, model_editor=model_editor
         )
         self.output_calib_manager = OutputCalibManager(
             output_calibrator=output_calibrator

--- a/fortuna/utils/grad.py
+++ b/fortuna/utils/grad.py
@@ -1,0 +1,63 @@
+from functools import partial
+from typing import (
+    Callable,
+    Dict,
+    Tuple,
+    Union,
+)
+
+from jax import (
+    grad,
+    lax,
+    vjp,
+    vmap,
+)
+import jax.numpy as jnp
+from jax.tree_util import (
+    tree_map,
+    tree_reduce,
+)
+
+from fortuna.typing import (
+    InputData,
+    Params,
+)
+
+
+def value_and_jacobian_squared_row_norm(
+    apply_fn: Callable[
+        [Params, InputData], Union[jnp.ndarray, Tuple[jnp.ndarray, Dict]]
+    ],
+    params: Params,
+    x: InputData,
+    has_aux: bool = False,
+) -> Tuple[Union[jnp.ndarray, Tuple[jnp.ndarray, Dict]], jnp.ndarray]:
+    def _apply_fn(_p, _x):
+        _f = apply_fn(_p, _x)
+        if has_aux:
+            _f, _ = _f
+        return _f[0]
+
+    f = apply_fn(params, x)
+    if has_aux:
+        f, aux = f
+    n_dim = f.shape[-1]
+
+    def jacobian_squared_row_norm_fn(i):
+        return tree_reduce(
+            lambda a, b: a + jnp.sum(b**2),
+            vmap(lambda _x: grad(lambda p: _apply_fn(p, _x)[i])(params))(
+                x[:, None]
+                if not isinstance(x, dict)
+                else tree_map(lambda v: v[:, None], x)
+            ),
+            initializer=0,
+        )
+
+    jac_squared_row_norm = jnp.array(
+        lax.map(jacobian_squared_row_norm_fn, jnp.arange(n_dim))
+    )
+
+    if has_aux:
+        return (f, aux), jac_squared_row_norm
+    return f, jac_squared_row_norm

--- a/fortuna/utils/probit.py
+++ b/fortuna/utils/probit.py
@@ -1,0 +1,34 @@
+from typing import (
+    Callable,
+    Dict,
+    Tuple,
+    Union,
+)
+
+import jax.numpy as jnp
+
+from fortuna.typing import (
+    Array,
+    InputData,
+    Params,
+)
+from fortuna.utils.grad import value_and_jacobian_squared_row_norm
+
+
+def probit_scaling(
+    apply_fn: Callable[[Params, InputData], jnp.ndarray],
+    params: Params,
+    x: InputData,
+    log_var: Union[float, Array],
+    has_aux: bool = False,
+) -> Union[jnp.ndarray, Tuple[jnp.ndarray, Dict]]:
+    f, jacobian_squared_row_norm = value_and_jacobian_squared_row_norm(
+        apply_fn, params, x, has_aux=has_aux
+    )
+    if has_aux:
+        f, aux = f
+    f /= 1 + jnp.pi / 8 * jnp.exp(log_var) * jacobian_squared_row_norm
+
+    if has_aux:
+        return f, aux
+    return f


### PR DESCRIPTION
Add a `ModelEditor` object to `ProbModel` and `CalibModel`. It allows to take the forward pass, as a function of parameters and inputs, and apply a custom transformation to the outputs. The parameters of the `ModelEditor` will be added to the tree optimizer, and they will be tuned according to the method in use.

The model editor provides the functionality to exploit a multi-class probit approximation of the predictive distribution. We provide this explicitly in Fortuna.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):