### PR TITLE
Approximate conformal Bayes for classifiers

### DIFF
--- a/benchmarks/confbayes/example_2moons_CB.py
+++ b/benchmarks/confbayes/example_2moons_CB.py
@@ -1,22 +1,31 @@
 # Approximate Conformal Bayes: 2 Moons Example
 
-## Simulate data 
-from sklearn.datasets import make_moons
+## Simulate data
 import numpy as np
+from sklearn.datasets import make_moons
+
 n = 1000
 train_data = make_moons(n_samples=n, noise=0.2, random_state=0)
 n_test = 500
 test_data = make_moons(n_samples=n_test, noise=0.2, random_state=1)
 
-## Fit Flax models
-#Train model
-from fortuna.data import DataLoader
-from fortuna.prob_model import ProbClassifier, ADVIPosteriorApproximator
-from fortuna.model import MLP
 import flax.linen as nn
-from fortuna.prob_model import FitConfig, FitMonitor, FitOptimizer, CalibConfig, CalibMonitor
-from fortuna.metric.classification import accuracy
 import optax
+
+## Fit Flax models
+# Train model
+from fortuna.data import DataLoader
+from fortuna.metric.classification import accuracy
+from fortuna.model import MLP
+from fortuna.prob_model import (
+    ADVIPosteriorApproximator,
+    CalibConfig,
+    CalibMonitor,
+    FitConfig,
+    FitMonitor,
+    FitOptimizer,
+    ProbClassifier,
+)
 
 train_data_loader = DataLoader.from_array_data(
     train_data, batch_size=128, shuffle=True, prefetch=True
@@ -29,71 +38,78 @@ prob_model = ProbClassifier(
 )
 
 status = prob_model.train(
-    train_data_loader=train_data_loader, #Remove validation set to make it simpler
+    train_data_loader=train_data_loader,  # Remove validation set to make it simpler
     fit_config=FitConfig(
         monitor=FitMonitor(metrics=(accuracy,), early_stopping_patience=10),
         optimizer=FitOptimizer(method=optax.adam(1e-1)),
     ),
-    calib_config=CalibConfig(monitor=CalibMonitor(early_stopping_patience=2))
+    calib_config=CalibConfig(monitor=CalibMonitor(early_stopping_patience=2)),
 )
 
 ### Setup data loader and run conformal Bayes
 import jax.numpy as jnp
 
-#Duplicate test dataset with Y = 0 and Y = 1 (grid values)
-test_data_all0 = (test_data[0],np.zeros(n_test))
-test_data_all1 = (test_data[0],np.ones(n_test))
+# Duplicate test dataset with Y = 0 and Y = 1 (grid values)
+test_data_all0 = (test_data[0], np.zeros(n_test))
+test_data_all1 = (test_data[0], np.ones(n_test))
 
-#Combine training data and test data grid (with both Y = 0 and Y = 1) into big matrix, so random posterior samples are the same rng
-train_test_data = (jnp.concatenate((train_data[0],test_data_all0[0],test_data_all1[0]),axis = 0),
-                   jnp.concatenate((train_data[1],test_data_all0[1],test_data_all1[1]),axis = 0))
+# Combine training data and test data grid (with both Y = 0 and Y = 1) into big matrix, so random posterior samples are the same rng
+train_test_data = (
+    jnp.concatenate((train_data[0], test_data_all0[0], test_data_all1[0]), axis=0),
+    jnp.concatenate((train_data[1], test_data_all0[1], test_data_all1[1]), axis=0),
+)
 
-train_test_data_loader = DataLoader.from_array_data(train_test_data, batch_size=128, prefetch=True)
+train_test_data_loader = DataLoader.from_array_data(
+    train_test_data, batch_size=128, prefetch=True
+)
 
-#Fit conformal Bayes
+# Fit conformal Bayes
 error = 0.2
-conf_set,ESS = prob_model.predictive.conformal_set(train_test_data_loader, n, n_test, error = error, n_posterior_samples = 100, ESS = True)
+conf_set, ESS = prob_model.predictive.conformal_set(
+    train_test_data_loader, n, n_test, error=error, n_posterior_samples=100, ESS=True
+)
 
 ### Evaluate conformal Bayes
-#Evaluate conformal method
+# Evaluate conformal method
 cov = np.zeros(n_test)
 length = np.zeros(n_test)
-y_test = test_data[1] #test data points
+y_test = test_data[1]  # test data points
 
-#Loop through test data points and compute conformal sets for each
-for j in (range(n_test)):
-  cov[j] = conf_set[j][y_test[j]]
-  length[j] = jnp.sum(conf_set[j])
+# Loop through test data points and compute conformal sets for each
+for j in range(n_test):
+    cov[j] = conf_set[j][y_test[j]]
+    length[j] = jnp.sum(conf_set[j])
 
-print('Coverage for CB in test set = {}'.format(jnp.mean(cov)))
-print('Mean set length for CB = {}'.format(jnp.mean(length)))
-print('Mean effective sample size for IS = {}'.format(jnp.mean(ESS)))
-
+print("Coverage for CB in test set = {}".format(jnp.mean(cov)))
+print("Mean set length for CB = {}".format(jnp.mean(length)))
+print("Mean effective sample size for IS = {}".format(jnp.mean(ESS)))
 
 
 ### Evaluate regular Bayesian credible sets
 # Naive Bayes predictive method and evaluation
 from jax.scipy.special import logsumexp
 
-test_data_loader = DataLoader.from_array_data(test_data_all1, batch_size=128, prefetch=True)
+test_data_loader = DataLoader.from_array_data(
+    test_data_all1, batch_size=128, prefetch=True
+)
 test1_log_probs = prob_model.predictive.log_prob(data_loader=test_data_loader)
-p_bayes = jnp.exp(test1_log_probs) #P(Y =1 |x) under Bayesian model
+p_bayes = jnp.exp(test1_log_probs)  # P(Y =1 |x) under Bayesian model
 
-conf_set_bayes = np.zeros((n_test,2))
+conf_set_bayes = np.zeros((n_test, 2))
 cov_bayes = np.zeros(n_test)
 length_bayes = np.zeros(n_test)
 
-for j in (range(n_test)):
-  #Compute region from p_bayes
-  if p_bayes[j] >(1-error): #only y = 1
-      conf_set_bayes[j] = np.array([0,1])
-  elif (1-p_bayes[j]) >(1-error):  #only y = 0
-      conf_set_bayes[j] = np.array([1,0])
-  else:
-      conf_set_bayes[j] = np.array([1,1])
+for j in range(n_test):
+    # Compute region from p_bayes
+    if p_bayes[j] > (1 - error):  # only y = 1
+        conf_set_bayes[j] = np.array([0, 1])
+    elif (1 - p_bayes[j]) > (1 - error):  # only y = 0
+        conf_set_bayes[j] = np.array([1, 0])
+    else:
+        conf_set_bayes[j] = np.array([1, 1])
 
-  cov_bayes[j] = conf_set_bayes[j][y_test[j]]
-  length_bayes[j] = jnp.sum(conf_set_bayes[j])
+    cov_bayes[j] = conf_set_bayes[j][y_test[j]]
+    length_bayes[j] = jnp.sum(conf_set_bayes[j])
 
-print('Coverage for Bayes in test set = {}'.format(jnp.mean(cov_bayes)))
-print('Mean set length for Bayes = {}'.format(jnp.mean(length_bayes)))
+print("Coverage for Bayes in test set = {}".format(jnp.mean(cov_bayes)))
+print("Mean set length for Bayes = {}".format(jnp.mean(length_bayes)))

--- a/benchmarks/confbayes/example_2moons_CB.py
+++ b/benchmarks/confbayes/example_2moons_CB.py
@@ -1,0 +1,99 @@
+# Approximate Conformal Bayes: 2 Moons Example
+
+## Simulate data 
+from sklearn.datasets import make_moons
+import numpy as np
+n = 1000
+train_data = make_moons(n_samples=n, noise=0.2, random_state=0)
+n_test = 500
+test_data = make_moons(n_samples=n_test, noise=0.2, random_state=1)
+
+## Fit Flax models
+#Train model
+from fortuna.data import DataLoader
+from fortuna.prob_model import ProbClassifier, ADVIPosteriorApproximator
+from fortuna.model import MLP
+import flax.linen as nn
+from fortuna.prob_model import FitConfig, FitMonitor, FitOptimizer, CalibConfig, CalibMonitor
+from fortuna.metric.classification import accuracy
+import optax
+
+train_data_loader = DataLoader.from_array_data(
+    train_data, batch_size=128, shuffle=True, prefetch=True
+)
+
+output_dim = 2
+prob_model = ProbClassifier(
+    model=MLP(output_dim=output_dim, activations=(nn.tanh, nn.tanh)),
+    posterior_approximator=ADVIPosteriorApproximator(),
+)
+
+status = prob_model.train(
+    train_data_loader=train_data_loader, #Remove validation set to make it simpler
+    fit_config=FitConfig(
+        monitor=FitMonitor(metrics=(accuracy,), early_stopping_patience=10),
+        optimizer=FitOptimizer(method=optax.adam(1e-1)),
+    ),
+    calib_config=CalibConfig(monitor=CalibMonitor(early_stopping_patience=2))
+)
+
+### Setup data loader and run conformal Bayes
+import jax.numpy as jnp
+
+#Duplicate test dataset with Y = 0 and Y = 1 (grid values)
+test_data_all0 = (test_data[0],np.zeros(n_test))
+test_data_all1 = (test_data[0],np.ones(n_test))
+
+#Combine training data and test data grid (with both Y = 0 and Y = 1) into big matrix, so random posterior samples are the same rng
+train_test_data = (jnp.concatenate((train_data[0],test_data_all0[0],test_data_all1[0]),axis = 0),
+                   jnp.concatenate((train_data[1],test_data_all0[1],test_data_all1[1]),axis = 0))
+
+train_test_data_loader = DataLoader.from_array_data(train_test_data, batch_size=128, prefetch=True)
+
+#Fit conformal Bayes
+error = 0.2
+conf_set,ESS = prob_model.predictive.conformal_set(train_test_data_loader, n, n_test, error = error, n_posterior_samples = 100, ESS = True)
+
+### Evaluate conformal Bayes
+#Evaluate conformal method
+cov = np.zeros(n_test)
+length = np.zeros(n_test)
+y_test = test_data[1] #test data points
+
+#Loop through test data points and compute conformal sets for each
+for j in (range(n_test)):
+  cov[j] = conf_set[j][y_test[j]]
+  length[j] = jnp.sum(conf_set[j])
+
+print('Coverage for CB in test set = {}'.format(jnp.mean(cov)))
+print('Mean set length for CB = {}'.format(jnp.mean(length)))
+print('Mean effective sample size for IS = {}'.format(jnp.mean(ESS)))
+
+
+
+### Evaluate regular Bayesian credible sets
+# Naive Bayes predictive method and evaluation
+from jax.scipy.special import logsumexp
+
+test_data_loader = DataLoader.from_array_data(test_data_all1, batch_size=128, prefetch=True)
+test1_log_probs = prob_model.predictive.log_prob(data_loader=test_data_loader)
+p_bayes = jnp.exp(test1_log_probs) #P(Y =1 |x) under Bayesian model
+
+conf_set_bayes = np.zeros((n_test,2))
+cov_bayes = np.zeros(n_test)
+length_bayes = np.zeros(n_test)
+
+for j in (range(n_test)):
+  #Compute region from p_bayes
+  if p_bayes[j] >(1-error): #only y = 1
+      conf_set_bayes[j] = np.array([0,1])
+  elif (1-p_bayes[j]) >(1-error):  #only y = 0
+      conf_set_bayes[j] = np.array([1,0])
+  else:
+      conf_set_bayes[j] = np.array([1,1])
+
+  cov_bayes[j] = conf_set_bayes[j][y_test[j]]
+  length_bayes[j] = jnp.sum(conf_set_bayes[j])
+
+print('Coverage for Bayes in test set = {}'.format(jnp.mean(cov_bayes)))
+print('Mean set length for Bayes = {}'.format(jnp.mean(length_bayes)))

--- a/fortuna/prob_model/predictive/base.py
+++ b/fortuna/prob_model/predictive/base.py
@@ -58,6 +58,35 @@ class Predictive(WithRNG):
         distribute: bool = True,
         **kwargs,
     ) -> jnp.ndarray:
+        r"""
+        Compute the log-likelihood at each posterior sample, that is
+
+        .. math::
+            \log p(y|x, theta^{(i)}),
+
+        where:
+         - :math:`x` is an observed input variable;
+         - :math:`y` is an observed target variable;
+         - :math:`theta^{(i)}` is a sample from the posterior.
+
+        Parameters
+        ----------
+        data_loader : DataLoader
+            A data loader.
+        n_posterior_samples : int
+            Number of posterior samples to draw in order to compute the log -ikelihood.
+            that would be produced using the posterior distribution state.
+        rng : Optional[PRNGKeyArray]
+            A random number generator. If not passed, this will be taken from the attributes of this class.
+        distribute: bool
+            Whether to distribute computation over multiple devices, if available.
+
+        Returns
+        -------
+        jnp.ndarray
+            An array of log-likelihood values at each posterior sample for each data point.
+        """
+
         if rng is None:
             rng = self.rng.get()
 

--- a/fortuna/prob_model/predictive/base.py
+++ b/fortuna/prob_model/predictive/base.py
@@ -49,7 +49,7 @@ class Predictive(WithRNG):
         self.likelihood = posterior.joint.likelihood
         self.posterior = posterior
 
-####
+    ####
     def ensemble_log_prob(
         self,
         data_loader: DataLoader,
@@ -57,7 +57,7 @@ class Predictive(WithRNG):
         rng: Optional[PRNGKeyArray] = None,
         distribute: bool = True,
         **kwargs,
-    ) -> jnp.ndarray:    
+    ) -> jnp.ndarray:
         if rng is None:
             rng = self.rng.get()
 
@@ -69,9 +69,8 @@ class Predictive(WithRNG):
             distribute,
             **kwargs,
         )
-        
-        return log_probs.swapaxes(0,1)
 
+        return log_probs.swapaxes(0, 1)
 
     def _batched_ensemble_log_prob(
         self,
@@ -95,8 +94,11 @@ class Predictive(WithRNG):
                 **kwargs,
             )
 
-        return lax.map(_lik_log_batched_prob, keys).swapaxes(0,1) # notice that we use lax.map and not vmap to avoid parallel posterior sampling
-####
+        return lax.map(_lik_log_batched_prob, keys).swapaxes(
+            0, 1
+        )  # notice that we use lax.map and not vmap to avoid parallel posterior sampling
+
+    ####
     def log_prob(
         self,
         data_loader: DataLoader,

--- a/fortuna/prob_model/predictive/base.py
+++ b/fortuna/prob_model/predictive/base.py
@@ -49,6 +49,54 @@ class Predictive(WithRNG):
         self.likelihood = posterior.joint.likelihood
         self.posterior = posterior
 
+####
+    def ensemble_log_prob(
+        self,
+        data_loader: DataLoader,
+        n_posterior_samples: int = 30,
+        rng: Optional[PRNGKeyArray] = None,
+        distribute: bool = True,
+        **kwargs,
+    ) -> jnp.ndarray:    
+        if rng is None:
+            rng = self.rng.get()
+
+        log_probs = self._loop_fun_through_data_loader(
+            self._batched_ensemble_log_prob,
+            data_loader,
+            n_posterior_samples,
+            rng,
+            distribute,
+            **kwargs,
+        )
+        
+        return log_probs.swapaxes(0,1)
+
+
+    def _batched_ensemble_log_prob(
+        self,
+        batch: Batch,
+        n_posterior_samples: int = 30,
+        rng: Optional[PRNGKeyArray] = None,
+        **kwargs,
+    ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, dict]]:
+        if rng is None:
+            rng = self.rng.get()
+        keys = random.split(rng, n_posterior_samples)
+
+        def _lik_log_batched_prob(key):
+            sample = self.posterior.sample(inputs=batch[0], rng=key)
+            return self.likelihood._batched_log_prob(
+                sample.params,
+                batch,
+                mutable=sample.mutable,
+                calib_params=sample.calib_params,
+                calib_mutable=sample.calib_mutable,
+                **kwargs,
+            )
+
+        return lax.map(_lik_log_batched_prob, keys).swapaxes(0,1) # notice that we use lax.map and not vmap to avoid parallel posterior sampling
+####
     def log_prob(
         self,
         data_loader: DataLoader,

--- a/fortuna/prob_model/predictive/classification.py
+++ b/fortuna/prob_model/predictive/classification.py
@@ -424,7 +424,7 @@ class ClassificationPredictive(Predictive):
             return jnp.exp(log_preds) * log_preds
 
         return -jnp.sum(vmap(_entropy_term)(jnp.arange(n_classes)), 0)
-    
+
     def conformal_set(
         self,
         train_test_data_loader: InputsLoader,
@@ -436,12 +436,12 @@ class ClassificationPredictive(Predictive):
         ESS: bool = False,
     ) -> jnp.ndarray:
         r"""
-        Estimate conformal sets for the target variable. 
+        Estimate conformal sets for the target variable.
 
         Parameters
         ----------
         train_test_data_loader : InputsLoader
-            A loader of input data points where the first n data are training, 
+            A loader of input data points where the first n data are training,
             followed by n_test with Y = 0 then n_test with Y = 1.
         n : int
             Size of training set
@@ -461,66 +461,88 @@ class ClassificationPredictive(Predictive):
         -------
         jnp.ndarray
             A conformal set for each of the inputs.
-        """     
-        #returns n_posterior_samples x (n_test + n_test +n)
-        ensemble_train_test_log_probs = self.ensemble_log_prob(data_loader=train_test_data_loader, n_posterior_samples = n_posterior_samples)
+        """
+        # returns n_posterior_samples x (n_test + n_test +n)
+        ensemble_train_test_log_probs = self.ensemble_log_prob(
+            data_loader=train_test_data_loader, n_posterior_samples=n_posterior_samples
+        )
 
-        #Divide back out into test set grid and training
-        ensemble_train_log_probs = ensemble_train_test_log_probs[:,0:n] #training log likelihood
-        ensemble_test0_log_probs = ensemble_train_test_log_probs[:,n:n + n_test] #test log likelihoods at Y = 0
-        ensemble_test1_log_probs= ensemble_train_test_log_probs[:,n+n_test:n+2*n_test] #test log likelihoods at Y = 1
+        # Divide back out into test set grid and training
+        ensemble_train_log_probs = ensemble_train_test_log_probs[
+            :, 0:n
+        ]  # training log likelihood
+        ensemble_test0_log_probs = ensemble_train_test_log_probs[
+            :, n : n + n_test
+        ]  # test log likelihoods at Y = 0
+        ensemble_test1_log_probs = ensemble_train_test_log_probs[
+            :, n + n_test : n + 2 * n_test
+        ]  # test log likelihoods at Y = 1
 
-        #log likelihood values for each test input, posterior sample, and grid point (shape =  n_test x  n_posterior_samples x 2)
-        ensemble_testgrid_log_probs = (jnp.concatenate((ensemble_test0_log_probs.T.reshape(-1,n_posterior_samples,1),
-                                                         ensemble_test1_log_probs.T.reshape(-1,n_posterior_samples,1)),axis = 2))
+        # log likelihood values for each test input, posterior sample, and grid point (shape =  n_test x  n_posterior_samples x 2)
+        ensemble_testgrid_log_probs = jnp.concatenate(
+            (
+                ensemble_test0_log_probs.T.reshape(-1, n_posterior_samples, 1),
+                ensemble_test1_log_probs.T.reshape(-1, n_posterior_samples, 1),
+            ),
+            axis=2,
+        )
 
-
-        @jit #compute rank of nonconformity score (unnormalized by n+1)
+        @jit  # compute rank of nonconformity score (unnormalized by n+1)
         def _compute_cb_region_IS(ensemble_testgrid_log_probs):
-            n= jnp.shape(ensemble_train_log_probs)[1] #ensemble_train_log_probs is n_posterior_samples x n; training data log likelihood values
-            n_plot = jnp.shape(ensemble_testgrid_log_probs)[1] #ensemble_testgrid_log_probs is n_posterior_samples x n_plot_grid;  test data log likelihood values for each posterior sample
+            n = jnp.shape(ensemble_train_log_probs)[
+                1
+            ]  # ensemble_train_log_probs is n_posterior_samples x n; training data log likelihood values
+            n_plot = jnp.shape(ensemble_testgrid_log_probs)[
+                1
+            ]  # ensemble_testgrid_log_probs is n_posterior_samples x n_plot_grid;  test data log likelihood values for each posterior sample
             rank_cp = jnp.zeros(n_plot)
 
-            #compute importance sampling weights and normalizing
+            # compute importance sampling weights and normalizing
             wjk = jnp.exp(ensemble_testgrid_log_probs.T)
-            Zjk = jnp.sum(wjk,axis = 1).reshape(-1,1)
+            Zjk = jnp.sum(wjk, axis=1).reshape(-1, 1)
 
-            #compute predictives for y_i,x_i and y_new,x_n+1
-            p_cp = jnp.dot(wjk/Zjk, jnp.exp(ensemble_train_log_probs))
-            p_new = jnp.sum(wjk**2,axis = 1).reshape(-1,1)/Zjk
+            # compute predictives for y_i,x_i and y_new,x_n+1
+            p_cp = jnp.dot(wjk / Zjk, jnp.exp(ensemble_train_log_probs))
+            p_new = jnp.sum(wjk**2, axis=1).reshape(-1, 1) / Zjk
 
-            #compute nonconformity score and sort
-            pred_tot = jnp.concatenate((p_cp,p_new),axis = 1)
-            rank_cp = jnp.sum(pred_tot <= pred_tot[:,-1].reshape(-1,1),axis = 1)
+            # compute nonconformity score and sort
+            pred_tot = jnp.concatenate((p_cp, p_new), axis=1)
+            rank_cp = jnp.sum(pred_tot <= pred_tot[:, -1].reshape(-1, 1), axis=1)
 
-            #Compute region of grid which is in confidence set
-            region_true =rank_cp> error*(n+1)
+            # Compute region of grid which is in confidence set
+            region_true = rank_cp > error * (n + 1)
             return region_true
 
-        #Compute CB interval for each
+        # Compute CB interval for each
         conf_set = vmap(_compute_cb_region_IS)(ensemble_testgrid_log_probs)
 
         if ESS:
-          ## DIAGNOSE IMPORTANCE WEIGHTS ##
-          @jit #compute Effective sample size
-          def _diagnose_is_weights(ensemble_testgrid_log_probs):
-              n= jnp.shape(ensemble_train_log_probs)[1] #ensemble_train_log_probs is n_posterior_samples x n
-              n_plot = jnp.shape(ensemble_testgrid_log_probs)[1] #ensemble_testgrid_log_probs is n_posterior_samples x n_plot_grid
-              rank_cp = jnp.zeros(n_plot)
+            ## DIAGNOSE IMPORTANCE WEIGHTS ##
+            @jit  # compute Effective sample size
+            def _diagnose_is_weights(ensemble_testgrid_log_probs):
+                n = jnp.shape(ensemble_train_log_probs)[
+                    1
+                ]  # ensemble_train_log_probs is n_posterior_samples x n
+                n_plot = jnp.shape(ensemble_testgrid_log_probs)[
+                    1
+                ]  # ensemble_testgrid_log_probs is n_posterior_samples x n_plot_grid
+                rank_cp = jnp.zeros(n_plot)
 
-              #compute importance sampling weights and normalizing
-              logwjk = ensemble_testgrid_log_probs.T.reshape(n_plot,-1, 1)
-              logZjk = jsp.special.logsumexp(logwjk,axis = 1)
+                # compute importance sampling weights and normalizing
+                logwjk = ensemble_testgrid_log_probs.T.reshape(n_plot, -1, 1)
+                logZjk = jsp.special.logsumexp(logwjk, axis=1)
 
-              #compute predictives for y_i,x_i and y_new,x_n+1
-              logp_new = jsp.special.logsumexp(2*logwjk,axis = 1)-logZjk
+                # compute predictives for y_i,x_i and y_new,x_n+1
+                logp_new = jsp.special.logsumexp(2 * logwjk, axis=1) - logZjk
 
-              #compute ESS
-              wjk = jnp.exp(logwjk - logZjk.reshape(-1,1,1))
-              ESS = 1/jnp.sum(wjk**2,axis = 1)
-              return ESS
-          ###
-          ESS = vmap(_diagnose_is_weights)(ensemble_testgrid_log_probs)
-          return conf_set, ESS
-          
-        else: return conf_set
+                # compute ESS
+                wjk = jnp.exp(logwjk - logZjk.reshape(-1, 1, 1))
+                ESS = 1 / jnp.sum(wjk**2, axis=1)
+                return ESS
+
+            ###
+            ESS = vmap(_diagnose_is_weights)(ensemble_testgrid_log_probs)
+            return conf_set, ESS
+
+        else:
+            return conf_set

--- a/fortuna/prob_model/predictive/classification.py
+++ b/fortuna/prob_model/predictive/classification.py
@@ -424,3 +424,103 @@ class ClassificationPredictive(Predictive):
             return jnp.exp(log_preds) * log_preds
 
         return -jnp.sum(vmap(_entropy_term)(jnp.arange(n_classes)), 0)
+    
+    def conformal_set(
+        self,
+        train_test_data_loader: InputsLoader,
+        n: int,
+        n_test: int,
+        n_posterior_samples: int = 30,
+        error: float = 0.05,
+        rng: Optional[PRNGKeyArray] = None,
+        ESS: bool = False,
+    ) -> jnp.ndarray:
+        r"""
+        Estimate conformal sets for the target variable. 
+
+        Parameters
+        ----------
+        train_test_data_loader : InputsLoader
+            A loader of input data points where the first n data are training, 
+            followed by n_test with Y = 0 then n_test with Y = 1.
+        n : int
+            Size of training set
+        n_test : int
+            Size of test set
+        n_posterior_samples : int
+            Number of samples to draw from the posterior distribution for each input.
+        error: float
+            The interval error. This must be a number between 0 and 1, extremes included. For example,
+            `error=0.05` corresponds to a 95% level of confidence.
+        rng : Optional[PRNGKeyArray]
+            A random number generator. If not passed, this will be taken from the attributes of this class.
+        ESS: bool
+            Whether to compute ESS of importance weights or not.
+
+        Returns
+        -------
+        jnp.ndarray
+            A conformal set for each of the inputs.
+        """     
+        #returns n_posterior_samples x (n_test + n_test +n)
+        ensemble_train_test_log_probs = self.ensemble_log_prob(data_loader=train_test_data_loader, n_posterior_samples = n_posterior_samples)
+
+        #Divide back out into test set grid and training
+        ensemble_train_log_probs = ensemble_train_test_log_probs[:,0:n] #training log likelihood
+        ensemble_test0_log_probs = ensemble_train_test_log_probs[:,n:n + n_test] #test log likelihoods at Y = 0
+        ensemble_test1_log_probs= ensemble_train_test_log_probs[:,n+n_test:n+2*n_test] #test log likelihoods at Y = 1
+
+        #log likelihood values for each test input, posterior sample, and grid point (shape =  n_test x  n_posterior_samples x 2)
+        ensemble_testgrid_log_probs = (jnp.concatenate((ensemble_test0_log_probs.T.reshape(-1,n_posterior_samples,1),
+                                                         ensemble_test1_log_probs.T.reshape(-1,n_posterior_samples,1)),axis = 2))
+
+
+        @jit #compute rank of nonconformity score (unnormalized by n+1)
+        def _compute_cb_region_IS(ensemble_testgrid_log_probs):
+            n= jnp.shape(ensemble_train_log_probs)[1] #ensemble_train_log_probs is n_posterior_samples x n; training data log likelihood values
+            n_plot = jnp.shape(ensemble_testgrid_log_probs)[1] #ensemble_testgrid_log_probs is n_posterior_samples x n_plot_grid;  test data log likelihood values for each posterior sample
+            rank_cp = jnp.zeros(n_plot)
+
+            #compute importance sampling weights and normalizing
+            wjk = jnp.exp(ensemble_testgrid_log_probs.T)
+            Zjk = jnp.sum(wjk,axis = 1).reshape(-1,1)
+
+            #compute predictives for y_i,x_i and y_new,x_n+1
+            p_cp = jnp.dot(wjk/Zjk, jnp.exp(ensemble_train_log_probs))
+            p_new = jnp.sum(wjk**2,axis = 1).reshape(-1,1)/Zjk
+
+            #compute nonconformity score and sort
+            pred_tot = jnp.concatenate((p_cp,p_new),axis = 1)
+            rank_cp = jnp.sum(pred_tot <= pred_tot[:,-1].reshape(-1,1),axis = 1)
+
+            #Compute region of grid which is in confidence set
+            region_true =rank_cp> error*(n+1)
+            return region_true
+
+        #Compute CB interval for each
+        conf_set = vmap(_compute_cb_region_IS)(ensemble_testgrid_log_probs)
+
+        if ESS:
+          ## DIAGNOSE IMPORTANCE WEIGHTS ##
+          @jit #compute Effective sample size
+          def _diagnose_is_weights(ensemble_testgrid_log_probs):
+              n= jnp.shape(ensemble_train_log_probs)[1] #ensemble_train_log_probs is n_posterior_samples x n
+              n_plot = jnp.shape(ensemble_testgrid_log_probs)[1] #ensemble_testgrid_log_probs is n_posterior_samples x n_plot_grid
+              rank_cp = jnp.zeros(n_plot)
+
+              #compute importance sampling weights and normalizing
+              logwjk = ensemble_testgrid_log_probs.T.reshape(n_plot,-1, 1)
+              logZjk = jsp.special.logsumexp(logwjk,axis = 1)
+
+              #compute predictives for y_i,x_i and y_new,x_n+1
+              logp_new = jsp.special.logsumexp(2*logwjk,axis = 1)-logZjk
+
+              #compute ESS
+              wjk = jnp.exp(logwjk - logZjk.reshape(-1,1,1))
+              ESS = 1/jnp.sum(wjk**2,axis = 1)
+              return ESS
+          ###
+          ESS = vmap(_diagnose_is_weights)(ensemble_testgrid_log_probs)
+          return conf_set, ESS
+          
+        else: return conf_set

--- a/fortuna/prob_model/predictive/classification.py
+++ b/fortuna/prob_model/predictive/classification.py
@@ -460,7 +460,8 @@ class ClassificationPredictive(Predictive):
         Returns
         -------
         jnp.ndarray
-            A conformal set for each of the inputs.
+            A conformal set for each of the inputs. Contains two columns with TRUE/FALSE, where the first and second columns indicate if
+            Y = 0 or Y = 1 respectively is included in the conformal set.
         """
         # returns n_posterior_samples x (n_test + n_test +n)
         ensemble_train_test_log_probs = self.ensemble_log_prob(

--- a/tests/fortuna/test_predictive.py
+++ b/tests/fortuna/test_predictive.py
@@ -84,6 +84,18 @@ class TestPredictives(unittest.TestCase):
             )
             assert log_probs.shape == (self.n_inputs,)
 
+            ensemble_log_probs = self.prob_class.predictive.ensemble_log_prob(
+                self.class_data_loader,
+                n_posterior_samples=self.n_post_samples,
+            )
+            assert ensemble_log_probs.shape == (self.n_post_samples, self.n_inputs)
+
+            ensemble_log_probs = self.prob_reg.predictive.ensemble_log_prob(
+                self.reg_data_loader,
+                n_posterior_samples=self.n_post_samples,
+            )
+            assert ensemble_log_probs.shape == (self.n_post_samples, self.n_inputs)
+
             sample = self.prob_class.predictive.sample(
                 self.class_inputs_loader,
                 n_target_samples=self.n_post_samples,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Implemented an approximate version of [Fong & Holmes (2021)](https://proceedings.neurips.cc/paper_files/paper/2021/file/97785e0500ad16c18574c64189ccf4b4-Paper.pdf) for classification
- Added an example script on 2 moons example

## Other information

- Currently, the user is required to manually construct a dataloader which concatenates the training data followed by the test data plugging in Y = 0 then Y = 1 (a grid of size 2). This is shown for example in lines 52-64 in `examples_2moons_CB.py`. Would it be possible to have the user pass in a train_data_loader and test_data_loader, then we construct this combined data loader together with the grid within `conformal_set`?
- Still need to add unit tests for conformal_set but will depend on how we handle the above.

Thank you! 

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->